### PR TITLE
Native lights: encapsulates frontlight dialog wrapper as a Device function

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -49,8 +49,8 @@ else
 fi
 
 #install our own updated shellcheck
-SHELLCHECK_VERSION="v0.7.0"
-SHELLCHECK_URL="https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz"
+SHELLCHECK_VERSION="v0.7.1"
+SHELLCHECK_URL="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz"
 if ! command -v shellcheck; then
     curl -sSL "${SHELLCHECK_URL}" | tar --exclude 'SHA256SUMS' --strip-components=1 -C "${HOME}/bin" -xJf -
     chmod +x "${HOME}/bin/shellcheck"

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -149,20 +149,17 @@ function CloudStorage:openCloudServer(url)
     local tbl
     local NetworkMgr = require("ui/network/manager")
     if self.type == "dropbox" then
-        if not NetworkMgr:isOnline() then
-            NetworkMgr:promptWifiOn()
+        if NetworkMgr:willRerunWhenOnline(function() self:openCloudServer(url) end) then
             return
         end
         tbl = DropBox:run(url, self.password, self.choose_folder_mode)
     elseif self.type == "ftp" then
-        if not NetworkMgr:isConnected() then
-            NetworkMgr:promptWifiOn()
+        if NetworkMgr:willRerunWhenConnected(function() self:openCloudServer(url) end) then
             return
         end
         tbl = Ftp:run(self.address, self.username, self.password, url)
     elseif self.type == "webdav" then
-        if not NetworkMgr:isConnected() then
-            NetworkMgr:promptWifiOn()
+        if NetworkMgr:willRerunWhenConnected(function() self:openCloudServer(url) end) then
             return
         end
         tbl = WebDav:run(self.address, self.username, self.password, url)

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -52,9 +52,12 @@ function Ftp:downloadFile(item, address, user, pass, path, close)
 end
 
 function Ftp:config(item, callback)
-    local text_info = "FTP address must be in the format ftp://example.domain.com\n"..
-        "Also supported is format with IP e.g: ftp://10.10.10.1\n"..
-        "Username and password are optional."
+    local text_info = _([[
+The FTP address must be in the following format:
+ftp://example.domain.com
+An IP address is also supported, for example:
+ftp://10.10.10.1
+Username and password are optional.]])
     local hint_name = _("Your FTP name")
     local text_name = ""
     local hint_address = _("FTP address eg ftp://example.com")

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -572,7 +572,8 @@ function ReaderBookmark:toggleBookmark(pn_or_xp)
         local notes = self.ui.toc:getTocTitleByPage(pn_or_xp)
         local chapter_name = notes
         if notes ~= "" then
-            notes = "in "..notes
+            -- @translators In which chapter title (%1) a note is found.
+            notes = T(_("in %1"), notes)
         end
         self:addBookmark({
             page = pn_or_xp,

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -836,11 +836,10 @@ function ReaderDictionary:showDownload(downloadable_dicts)
     for dummy, dict in ipairs(downloadable_dicts) do
         table.insert(kv_pairs, {dict.name, "",
             callback = function()
-                if not NetworkMgr:isOnline() then
-                    NetworkMgr:promptWifiOn()
-                    return
+                local connect_callback = function()
+                    self:downloadDictionaryPrep(dict)
                 end
-                self:downloadDictionaryPrep(dict)
+                NetworkMgr:runWhenOnline(connect_callback)
             end})
         local lang
         if dict.lang_in == dict.lang_out then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -57,7 +57,7 @@ local symbol_prefix = {
         frontlight = C_("FooterLetterPrefix", "L:"),
         -- @translators This is the footer letter prefix for memory usage.
         mem_usage = C_("FooterLetterPrefix", "M:"),
-        -- @translators This is the footer letter prefix for wifi status.
+        -- @translators This is the footer letter prefix for Wi-Fi status.
         wifi_status = C_("FooterLetterPrefix", "W:"),
     },
     icons = {
@@ -1835,7 +1835,7 @@ function ReaderFooter:applyFooterMode(mode)
     -- 7 for from statistics chapter time to read
     -- 8 for front light level
     -- 9 for memory usage
-    -- 10 for wifi status
+    -- 10 for Wi-Fi status
     -- 11 for book title
     -- 12 for current chapter
 

--- a/frontend/apps/reader/modules/readergesture.lua
+++ b/frontend/apps/reader/modules/readergesture.lua
@@ -184,7 +184,7 @@ function ReaderGesture:init()
         hold_bottom_right_corner = "ignore",
         one_finger_swipe_left_edge_down = Device:hasFrontlight() and "decrease_frontlight" or "ignore",
         one_finger_swipe_left_edge_up = Device:hasFrontlight() and "increase_frontlight" or "ignore",
-        one_finger_swipe_right_edge_down =  Device:hasNaturalLight() and "decrease_frontlight_warmth" or "ignore",
+        one_finger_swipe_right_edge_down = Device:hasNaturalLight() and "decrease_frontlight_warmth" or "ignore",
         one_finger_swipe_right_edge_up = Device:hasNaturalLight() and "increase_frontlight_warmth" or "ignore",
         one_finger_swipe_top_edge_right = "ignore",
         one_finger_swipe_top_edge_left = "ignore",

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -788,7 +788,7 @@ No OCR results or no language data.
 
 KOReader has a build-in OCR engine for recognizing words in scanned PDF and DjVu documents. In order to use OCR in scanned pages, you need to install tesseract trained data for your document language.
 
-You can download language data files for version 3.04 from https://github.com/tesseract-ocr/tesseract/wiki/Data-Files
+You can download language data files for version 3.04 from https://tesseract-ocr.github.io/tessdoc/Data-Files
 
 Copy the language data files for Tesseract 3.04 (e.g., eng.traineddata for English and spa.traineddata for Spanish) into koreader/data/tessdata]])
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -787,6 +787,7 @@ function ReaderRolling:updatePos()
         self.old_doc_height = new_height
         self.old_page = new_page
         self.ui:handleEvent(Event:new("UpdateToc"))
+        self.view.footer:setTocMarkers(true)
         self.view.footer:onUpdateFooter()
     end
     self:updateTopStatusBarMarkers()

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -827,7 +827,11 @@ end
 
 function ReaderView:onSaveSettings()
     self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
-    self.ui.doc_settings:saveSetting("rotation_mode", Screen:getRotationMode())
+    -- Don't etch the current rotation in stone when sticky rotation is enabled
+    local locked = G_reader_settings:isTrue("lock_rotation")
+    if not locked then
+        self.ui.doc_settings:saveSetting("rotation_mode", Screen:getRotationMode())
+    end
     self.ui.doc_settings:saveSetting("gamma", self.state.gamma)
     self.ui.doc_settings:saveSetting("highlight", self.highlight.saved)
     self.ui.doc_settings:saveSetting("page_overlap_style", self.page_overlap_style)

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -384,10 +384,11 @@ function ReaderWikipedia:onLookupWikipedia(word, box, get_fullpage, forced_lang)
 end
 
 function ReaderWikipedia:lookupWikipedia(word, box, get_fullpage, forced_lang)
-    if not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
+    if NetworkMgr:willRerunWhenOnline(function() self:lookupWikipedia(word, box, get_fullpage, forced_lang) end) then
+        -- Not online yet, nothing more to do here, NetworkMgr will forward the callback and run it once connected!
         return
     end
+
     -- word is the text to query. If get_fullpage is true, it is the
     -- exact wikipedia page title we want the full page of.
     self:initLanguages(word)
@@ -525,11 +526,10 @@ function ReaderWikipedia:onSaveSettings()
 end
 
 function ReaderWikipedia:onShowWikipediaLookup()
-    if NetworkMgr:isOnline() then
+    local connect_callback = function()
         self:lookupInput()
-    else
-        NetworkMgr:promptWifiOn()
     end
+    NetworkMgr:runWhenOnline(connect_callback)
     return true
 end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -377,6 +377,20 @@ function Device:canExecuteScript(file)
     end
 end
 
+function Device:lightDialog()
+    local usleep = require("ffi/util").usleep
+    android.settings.dialog(_("Frontlight settings"), _("Intensity"), _("Warmth"), _("Ok"))
+    repeat
+        usleep(75000) -- sleep 75ms before next check if dialog was quit
+    until (not android.isFrontlightDialogRunning())
+    logger.info("new brightness: " .. self.powerd.fl_intensity)
+    self.powerd:setIntensityHW(self.powerd:frontlightIntensityHW())
+    if android.isWarmthDevice() then
+        self.powerd:setWarmth(self.powerd:getWarmth())
+        logger.info("new warmth: " .. self.powerd.fl_warmth)
+    end
+end
+
 android.LOGI(string.format("Android %s - %s (API %d) - flavor: %s",
     android.prop.version, getCodename(), Device.firmware_rev, android.prop.flavor))
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -72,6 +72,7 @@ local Device = Generic:new{
     hasEinkScreen = function() return android.isEink() end,
     hasColorScreen = function() return not android.isEink() end,
     hasFrontlight = yes,
+    hasNaturalLight = android.isWarmthDevice,
     hasLightLevelFallback = yes,
     canRestart = no,
     canSuspend = no,
@@ -244,6 +245,7 @@ function Device:init()
         android.setBackButtonIgnored(true)
     end
 
+    -- TODO fl_last_level is a leftover from frontlightwidget
     -- check if we enable a custom light level for this activity
     local last_value = G_reader_settings:readSetting("fl_last_level")
     if type(last_value) == "number" and last_value >= 0 then
@@ -379,3 +381,4 @@ android.LOGI(string.format("Android %s - %s (API %d) - flavor: %s",
     android.prop.version, getCodename(), Device.firmware_rev, android.prop.flavor))
 
 return Device
+

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -2,17 +2,47 @@ local BasePowerD = require("device/generic/powerd")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
-    fl_min = 0, fl_max = 25,
-    fl_intensity = 10,
+    fl_min = 0, fl_max = 100, -- consistant scale across android, kobo ...
+--    fl_intensity = 10,
 }
 
 function AndroidPowerD:frontlightIntensityHW()
-    return math.floor(android.getScreenBrightness() / 255 * self.fl_max)
+    local intensity = math.floor(android.getScreenBrightness() / android.getScreenMaxBrightness() * self.fl_max)
+    if intensity < 0 then
+        intensity = 0
+    end
+    return intensity
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
-    android.setScreenBrightness(math.floor(255 * intensity / self.fl_max))
+    self.fl_intensity = intensity
+    android.setScreenBrightness(math.floor(intensity * android.getScreenMaxBrightness() / self.fl_max))
 end
+
+function AndroidPowerD:init()
+    if self.device:hasNaturalLight() then
+        self.fl_warmth = self.getWarmth()
+    end
+end
+
+function AndroidPowerD:setWarmth(warmth)
+    self.fl_warmth = warmth
+    android.setScreenWarmth( warmth / AndroidPowerD:getMaxWarmth() )
+end
+
+function AndroidPowerD:getWarmth()
+    local warmth = android.getScreenWarmth() * AndroidPowerD.getMaxWarmth()
+    return warmth
+end
+
+function AndroidPowerD:getMaxWarmth()
+    return android.getScreenMaxWarmth()
+end
+
+function AndroidPowerD:getMinWarmth()
+    return android.getScreenMinWarmth()
+end
+
 
 function AndroidPowerD:getCapacityHW()
     return android.getBatteryLevel()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -4,8 +4,6 @@ local _, android = pcall(require, "android")
 local AndroidPowerD = BasePowerD:new{
     fl_min = 0,
     fl_max = 100,
-    bright_diff = android.getScreenMaxBrightness() - android.getScreenMinBrightness(),
-    warm_diff = android.getScreenMaxWarmth() - android.getScreenMinWarmth(),
 }
 
 function AndroidPowerD:frontlightIntensityHW()
@@ -18,19 +16,20 @@ function AndroidPowerD:setIntensityHW(intensity)
 end
 
 function AndroidPowerD:init()
+    self.bright_diff = android:getScreenMaxBrightness() - android:getScreenMinBrightness()
     if self.device:hasNaturalLight() then
-        self.fl_warmth = self.getWarmth()
+        self.warm_diff = android:getScreenMaxWarmth() - android:getScreenMinWarmth()
+        self.fl_warmth = self:getWarmth()
     end
 end
 
 function AndroidPowerD:setWarmth(warmth)
     self.fl_warmth = warmth
-    android.setScreenWarmth(warmth / (android.getScreenWarmth() * self.warm_diff))
+    android.setScreenWarmth(warmth / self.warm_diff)
 end
 
 function AndroidPowerD:getWarmth()
-    local warmth = android.getScreenWarmth() * self.bright_diff
-    return warmth
+   return android.getScreenWarmth() * self.warm_diff
 end
 
 function AndroidPowerD:getCapacityHW()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -2,21 +2,19 @@ local BasePowerD = require("device/generic/powerd")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
-    fl_min = 0, fl_max = 100, -- consistant scale across android, kobo ...
---    fl_intensity = 10,
+    fl_min = 0,
+    fl_max = 100,
+    bright_diff = android.getScreenMaxBrightness() - android.getScreenMinBrightness(),
+    warm_diff = android.getScreenMaxWarmth() - android.getScreenMinWarmth(),
 }
 
 function AndroidPowerD:frontlightIntensityHW()
-    local intensity = math.floor(android.getScreenBrightness() / android.getScreenMaxBrightness() * self.fl_max)
-    if intensity < 0 then
-        intensity = 0
-    end
-    return intensity
+    return math.floor(android.getScreenBrightness() / self.bright_diff * self.fl_max)
 end
 
 function AndroidPowerD:setIntensityHW(intensity)
     self.fl_intensity = intensity
-    android.setScreenBrightness(math.floor(intensity * android.getScreenMaxBrightness() / self.fl_max))
+    android.setScreenBrightness(math.floor(intensity * self.bright_diff / self.fl_max))
 end
 
 function AndroidPowerD:init()
@@ -27,22 +25,13 @@ end
 
 function AndroidPowerD:setWarmth(warmth)
     self.fl_warmth = warmth
-    android.setScreenWarmth( warmth / AndroidPowerD:getMaxWarmth() )
+    android.setScreenWarmth(warmth / (android.getScreenWarmth() * self.warm_diff))
 end
 
 function AndroidPowerD:getWarmth()
-    local warmth = android.getScreenWarmth() * AndroidPowerD.getMaxWarmth()
+    local warmth = android.getScreenWarmth() * self.bright_diff
     return warmth
 end
-
-function AndroidPowerD:getMaxWarmth()
-    return android.getScreenMaxWarmth()
-end
-
-function AndroidPowerD:getMinWarmth()
-    return android.getScreenMinWarmth()
-end
-
 
 function AndroidPowerD:getCapacityHW()
     return android.getBatteryLevel()

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -17,7 +17,7 @@ local function isConnected()
     -- read carrier state from sysfs (for eth0)
     local file = io.open("/sys/class/net/eth0/carrier", "rb")
 
-    -- file exists while wifi module is loaded.
+    -- file exists while Wi-Fi module is loaded.
     if not file then return 0 end
 
     -- 0 means not connected, 1 connected
@@ -224,7 +224,7 @@ end
 -- wireless
 function Cervantes:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOffWifi(complete_callback)
-        logger.info("Cervantes: disabling WiFi")
+        logger.info("Cervantes: disabling Wi-Fi")
         self:releaseIP()
         os.execute("./disable-wifi.sh")
         if complete_callback then
@@ -232,9 +232,12 @@ function Cervantes:initNetworkManager(NetworkMgr)
         end
     end
     function NetworkMgr:turnOnWifi(complete_callback)
-        logger.info("Cervantes: enabling WiFi")
+        logger.info("Cervantes: enabling Wi-Fi")
         os.execute("./enable-wifi.sh")
         self:reconnectOrShowNetworkMenu(complete_callback)
+    end
+    function NetworkMgr:getNetworkInterfaceName()
+        return "eth0"
     end
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/eth0"})
     function NetworkMgr:obtainIP()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -114,12 +114,18 @@ if Device:hasFrontlight() then
 
         if new_intensity == nil then return true end
         -- when new_intensity <=0, toggle light off
+        self:onSetFlIntensity(new_intensity)
+        self:onShowIntensity()
+        return true
+    end
+
+    function DeviceListener:onSetFlIntensity(new_intensity)
+        local powerd = Device:getPowerDevice()
         if new_intensity <= 0 then
             powerd:turnOffFrontlight()
         else
             powerd:setIntensity(new_intensity)
         end
-        self:onShowIntensity()
         return true
     end
 
@@ -202,13 +208,19 @@ if Device:hasFrontlight() then
             direction = 1
         end
         local warmth = powerd.fl_warmth + direction * delta_int
+        self:onSetFlWarmth(warmth)
+        self:onShowWarmth()
+        return true
+    end
+
+    function DeviceListener:onSetFlWarmth(warmth)
+        local powerd = Device:getPowerDevice()
         if warmth > 100 then
             warmth = 100
         elseif warmth < 0 then
             warmth = 0
         end
         powerd:setWarmth(warmth)
-        self:onShowWarmth()
         return true
     end
 

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -282,12 +282,12 @@ function Device:onPowerEvent(ev)
         self.screen_saver_mode = true
         UIManager:scheduleIn(0.1, function()
           local network_manager = require("ui/network/manager")
-          -- NOTE: wifi_was_on does not necessarily mean that WiFi is *currently* on! It means *we* enabled it.
+          -- NOTE: wifi_was_on does not necessarily mean that Wi-Fi is *currently* on! It means *we* enabled it.
           --       This is critical on Kobos (c.f., #3936), where it might still be on from KSM or Nickel,
           --       without us being aware of it (i.e., wifi_was_on still unset or false),
-          --       because suspend will at best fail, and at worst deadlock the system if WiFi is on,
+          --       because suspend will at best fail, and at worst deadlock the system if Wi-Fi is on,
           --       regardless of who enabled it!
-          if network_manager.wifi_was_on or network_manager:isWifiOn() then
+          if network_manager:isWifiOn() then
               network_manager:releaseIP()
               network_manager:turnOffWifi()
           end

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -12,7 +12,7 @@ local function kindleEnableWifi(toggle)
     end
     if lipc_handle then
         -- Be extremely thorough... c.f., #6019
-        -- NOTE: I *assume* this'll also ensure we prefer WiFi over 3G/4G, which is a plus in my book...
+        -- NOTE: I *assume* this'll also ensure we prefer Wi-Fi over 3G/4G, which is a plus in my book...
         if toggle == 1 then
             lipc_handle:set_int_property("com.lab126.cmd", "wirelessEnable", 1)
             lipc_handle:set_int_property("com.lab126.wifid", "enable", 1)
@@ -103,20 +103,19 @@ function Kindle:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback)
         kindleEnableWifi(1)
         -- NOTE: As we defer the actual work to lipc,
-        --       we have no guarantee the WiFi state will have changed by the time kindleEnableWifi returns,
-        --       so, delay the callback a bit...
+        --       we have no guarantee the Wi-Fi state will have changed by the time kindleEnableWifi returns,
+        --       so, delay the callback until we at least can ensure isConnect is true.
         if complete_callback then
-            local UIManager = require("ui/uimanager")
-            UIManager:scheduleIn(1, complete_callback)
+            NetworkMgr:scheduleConnectivityCheck(complete_callback)
         end
     end
 
     function NetworkMgr:turnOffWifi(complete_callback)
         kindleEnableWifi(0)
-        -- NOTE: Same here...
+        -- NOTE: Same here, except disconnect is simpler, so a dumb delay will do...
         if complete_callback then
             local UIManager = require("ui/uimanager")
-            UIManager:scheduleIn(1, complete_callback)
+            UIManager:scheduleIn(2, complete_callback)
         end
     end
 
@@ -374,7 +373,7 @@ local KindleOasis = Kindle:new{
     hasGSensor = yes,
     display_dpi = 300,
     --[[
-    -- NOTE: Points to event3 on WiFi devices, event4 on 3G devices...
+    -- NOTE: Points to event3 on Wi-Fi devices, event4 on 3G devices...
     --       3G devices apparently have an extra SX9500 Proximity/Capacitive controller for mysterious purposes...
     --       This evidently screws with the ordering, so, use the udev by-path path instead to avoid hackier workarounds.
     --       cf. #2181
@@ -405,7 +404,7 @@ local KindlePaperWhite4 = Kindle:new{
     display_dpi = 300,
     -- NOTE: LTE devices once again have a mysterious extra SX9310 proximity sensor...
     --       Except this time, we can't rely on by-path, because there's no entry for the TS :/.
-    --       Should be event2 on WiFi, event3 on LTE, we'll fix it in init.
+    --       Should be event2 on Wi-Fi, event3 on LTE, we'll fix it in init.
     touch_dev = "/dev/input/event2",
 }
 

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -359,7 +359,7 @@ function Kobo:init()
     self.input.open("/dev/input/event0") -- Various HW Buttons, Switches & Synthetic NTX events
     self.input.open("/dev/input/event1")
     -- fake_events is only used for usb plug event so far
-    -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status
+    -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status (... but only when Nickel is running ;p)
     self.input.open("fake_events")
 
     if not self.needsTouchScreenProbe() then

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -10,11 +10,11 @@ local function yes() return true end
 local function no() return false end
 
 local function koboEnableWifi(toggle)
-    if toggle == 1 then
-        logger.info("Kobo WiFi: enabling WiFi")
+    if toggle == true then
+        logger.info("Kobo Wi-Fi: enabling Wi-Fi")
         os.execute("./enable-wifi.sh")
     else
-        logger.info("Kobo WiFi: disabling WiFi")
+        logger.info("Kobo Wi-Fi: disabling Wi-Fi")
         os.execute("./disable-wifi.sh")
     end
 end
@@ -414,20 +414,24 @@ end
 
 function Kobo:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOffWifi(complete_callback)
-        koboEnableWifi(0)
+        self:releaseIP()
+        koboEnableWifi(false)
         if complete_callback then
             complete_callback()
         end
     end
 
     function NetworkMgr:turnOnWifi(complete_callback)
-        koboEnableWifi(1)
+        koboEnableWifi(true)
         self:showNetworkMenu(complete_callback)
     end
 
     local net_if = os.getenv("INTERFACE")
     if not net_if then
         net_if = "eth0"
+    end
+    function NetworkMgr:getNetworkInterfaceName()
+        return net_if
     end
     NetworkMgr:setWirelessBackend(
         "wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/" .. net_if})
@@ -444,14 +448,14 @@ function Kobo:initNetworkManager(NetworkMgr)
         os.execute("./restore-wifi-async.sh")
     end
 
-    -- NOTE: Cheap-ass way of checking if WiFi seems to be enabled...
+    -- NOTE: Cheap-ass way of checking if Wi-Fi seems to be enabled...
     --       Since the crux of the issues lies in race-y module unloading, this is perfectly fine for our usage.
     function NetworkMgr:isWifiOn()
         local fd = io.open("/proc/modules", "r")
         if fd then
             local lsmod = fd:read("*all")
             fd:close()
-            -- lsmod is usually empty, unless WiFi or USB is enabled
+            -- lsmod is usually empty, unless Wi-Fi or USB is enabled
             -- We could alternatively check if lfs.attributes("/proc/sys/net/ipv4/conf/" .. os.getenv("INTERFACE"), "mode") == "directory"
             -- c.f., also what Cervantes does via /sys/class/net/eth0/carrier to check if the interface is up.
             -- That said, since we only care about whether *modules* are loaded, this does the job nicely.

--- a/frontend/device/sdl/powerd.lua
+++ b/frontend/device/sdl/powerd.lua
@@ -5,7 +5,7 @@ local SDLPowerD = BasePowerD:new{}
 
 function SDLPowerD:getCapacityHW()
     local _, _, _, percent = SDL.getPowerInfo()
-    -- never return negative values, since tests rely on battery being 0%
+    -- -1 looks a bit odd compared to 0
     if percent == -1 then return 0 end
     return percent
 end

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -158,6 +158,10 @@ function SonyPRSTUX:initNetworkManager(NetworkMgr)
        self:showNetworkMenu(complete_callback)
     end
 
+    function NetworkMgr:getNetworkInterfaceName()
+        return "wlan0"
+    end
+
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/wlan0"})
 
     function NetworkMgr:obtainIP()

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -302,7 +302,7 @@ function Dispatcher:init()
     Dispatcher.initialized = true
 end
 
-function Dispatcher.addItem(caller, menu, location, settings, section)
+function Dispatcher:addItem(menu, location, settings, section)
     for _, k in ipairs(dispatcher_menu_order) do
         if settingsList[k][section] == true and
             (settingsList[k].condition == nil or settingsList[k].condition)
@@ -311,15 +311,15 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
                 table.insert(menu, {
                     text = settingsList[k].title,
                     checked_func = function()
-                    return caller[location][settings] ~= nil and caller[location][settings][k] ~= nil
+                    return location[settings] ~= nil and location[settings][k] ~= nil
                     end,
                     callback = function(touchmenu_instance)
-                        if caller[location][settings] ~= nil
-                            and caller[location][settings][k]
+                        if location[settings] ~= nil
+                            and location[settings][k]
                         then
-                            caller[location][settings][k] = nil
+                            location[settings][k] = nil
                         else
-                            caller[location][settings][k] = true
+                            location[settings][k] = true
                         end
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                    end,
@@ -328,24 +328,24 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
             elseif settingsList[k].category == "absolutenumber" then
                 table.insert(menu, {
                     text_func = function()
-                        return T(settingsList[k].title, caller[location][settings][k] or "")
+                        return T(settingsList[k].title, location[settings][k] or "")
                     end,
                     checked_func = function()
-                    return caller[location][settings] ~= nil and caller[location][settings][k] ~= nil
+                    return location[settings] ~= nil and location[settings][k] ~= nil
                     end,
                     callback = function(touchmenu_instance)
                         local SpinWidget = require("ui/widget/spinwidget")
                         local items = SpinWidget:new{
                             width = Screen:getWidth() * 0.6,
-                            value = caller[location][settings][k] or settingsList[k].default or 0,
+                            value = location[settings][k] or settingsList[k].default or 0,
                             value_min = settingsList[k].min,
                             value_step = 1,
                             value_hold_step = 2,
                             value_max = settingsList[k].max,
                             default_value = 0,
-                            title_text = T(settingsList[k].title, caller[location][settings][k] or ""),
+                            title_text = T(settingsList[k].title, location[settings][k] or ""),
                             callback = function(spin)
-                                caller[location][settings][k] = spin.value
+                                location[settings][k] = spin.value
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -354,7 +354,7 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
                         UIManager:show(items)
                     end,
                     hold_callback = function(touchmenu_instance)
-                        caller[location][settings][k] = nil
+                        location[settings][k] = nil
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,
                     separator = settingsList[k].separator,
@@ -362,26 +362,26 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
             elseif settingsList[k].category == "incrementalnumber" then
                 table.insert(menu, {
                     text_func = function()
-                        return T(settingsList[k].title, caller[location][settings][k] or "")
+                        return T(settingsList[k].title, location[settings][k] or "")
                     end,
                     checked_func = function()
-                    return caller[location][settings] ~= nil and caller[location][settings][k] ~= nil
+                    return location[settings] ~= nil and location[settings][k] ~= nil
                     end,
                     callback = function(touchmenu_instance)
                         local _ = require("gettext")
                         local SpinWidget = require("ui/widget/spinwidget")
                         local items = SpinWidget:new{
                             width = Screen:getWidth() * 0.6,
-                            value = caller[location][settings][k] or 0,
+                            value = location[settings][k] or 0,
                             value_min = settingsList[k].min,
                             value_step = 1,
                             value_hold_step = 2,
                             value_max = settingsList[k].max,
                             default_value = 0,
-                            title_text = T(settingsList[k].title, caller[location][settings][k] or ""),
+                            title_text = T(settingsList[k].title, location[settings][k] or ""),
                             info_text = _([[If called by a gesture the amount of the gesture will be used]]),
                             callback = function(spin)
-                                caller[location][settings][k] = spin.value
+                                location[settings][k] = spin.value
                                 if touchmenu_instance then
                                     touchmenu_instance:updateItems()
                                 end
@@ -390,7 +390,7 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
                         UIManager:show(items)
                     end,
                     hold_callback = function(touchmenu_instance)
-                        caller[location][settings][k] = nil
+                        location[settings][k] = nil
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
                         end
@@ -403,27 +403,27 @@ function Dispatcher.addItem(caller, menu, location, settings, section)
                     table.insert(sub_item_table, {
                         text = tostring(settingsList[k].toggle[i]),
                         checked_func = function()
-                            return caller[location][settings] ~= nil
-                                and caller[location][settings][k] ~= nil
-                                and caller[location][settings][k] == settingsList[k].args[i]
+                            return location[settings] ~= nil
+                                and location[settings][k] ~= nil
+                                and location[settings][k] == settingsList[k].args[i]
                         end,
                         callback = function()
-                            caller[location][settings][k] = settingsList[k].args[i]
+                            location[settings][k] = settingsList[k].args[i]
                         end,
                     })
                 end
                 table.insert(menu, {
                     text_func = function()
-                        return T(settingsList[k].title, caller[location][settings][k])
+                        return T(settingsList[k].title, location[settings][k])
                     end,
                     checked_func = function()
-                        return caller[location][settings] ~= nil
-                            and caller[location][settings][k] ~= nil
+                        return location[settings] ~= nil
+                            and location[settings][k] ~= nil
                     end,
                     sub_item_table = sub_item_table,
                     keep_menu_open = true,
                     hold_callback = function(touchmenu_instance)
-                        caller[location][settings][k] = nil
+                        location[settings][k] = nil
                         if touchmenu_instance then
                             touchmenu_instance:updateItems()
                         end
@@ -438,27 +438,22 @@ end
 --[[--
 Add a submenu to edit which items are dispatched
 arguments are:
-    1) the caller
-    2) the table representing the submenu (can be empty)
-    3) the name of the parent of the settings table (must be a child of self)
-    4) the name of the settings table
+    1) the table representing the submenu (can be empty)
+    2) the object (table) in which the settings table is found
+    3) the name of the settings table
 example usage:
-    Dispatcher.addSubMenu(self, sub_items, "profiles", "profile1")
-
-Must be executed in the context of the caller to add items to the callers menu.
-therefore declared as Dispatcher.addSubMenu(caller, menu, location, settings)
-but should be called as Dispatcher.addSubMenu(self, menu, location, settings)
+    Dispatcher.addSubMenu(sub_items, self.data, "profile1")
 --]]--
-function Dispatcher.addSubMenu(caller, menu, location, settings)
+function Dispatcher:addSubMenu(menu, location, settings)
     if not Dispatcher.initialized then Dispatcher:init() end
     table.insert(menu, {
         text = _("None"),
         separator = true,
         checked_func = function()
-            return next(caller[location][settings]) == nil
+            return next(location[settings]) == nil
         end,
         callback = function(touchmenu_instance)
-            caller[location][settings] = {}
+            location[settings] = {}
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })
@@ -471,7 +466,7 @@ function Dispatcher.addSubMenu(caller, menu, location, settings)
     for _, section in ipairs(section_list) do
         local submenu = {}
         -- pass caller's context
-        Dispatcher.addItem(caller, submenu, location, settings, section[1])
+        Dispatcher:addItem(submenu, location, settings, section[1])
         table.insert(menu, {
             text = section[2],
             sub_item_table = submenu,
@@ -479,26 +474,33 @@ function Dispatcher.addSubMenu(caller, menu, location, settings)
     end
 end
 
-function Dispatcher:execute(settings, gesture)
+--[[--
+Calls the events in a settings list
+arguments are:
+    1) a reference to the uimanager
+    2) the settings table
+    3) optionally a `gestures`object
+--]]--
+function Dispatcher:execute(ui, settings, gesture)
     for k, v in pairs(settings) do
         if settingsList[k].conditions == nil or settingsList[k].conditions == true then
             if settingsList[k].category == "none" then
-                self.ui:handleEvent(Event:new(settingsList[k].event))
+                ui:handleEvent(Event:new(settingsList[k].event))
             end
             if settingsList[k].category == "absolutenumber"
                 or settingsList[k].category == "string"
             then
-                self.ui:handleEvent(Event:new(settingsList[k].event, v))
+                ui:handleEvent(Event:new(settingsList[k].event, v))
             end
             -- the event can accept a gesture object or an argument
             if settingsList[k].category == "arg" then
                 local arg = gesture or settingsList[k].arg
-                self.ui:handleEvent(Event:new(settingsList[k].event, arg))
+                ui:handleEvent(Event:new(settingsList[k].event, arg))
             end
             -- the event can accept a gesture object or a number
             if settingsList[k].category == "incrementalnumber" then
                 local arg = gesture or v
-                self.ui:handleEvent(Event:new(settingsList[k].event, arg))
+                ui:handleEvent(Event:new(settingsList[k].event, arg))
             end
         end
     end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -33,8 +33,10 @@ local settingsList = {
     -- Device settings
     show_frontlight_dialog = { category="none", event="ShowFlDialog", title=_("Show frontlight dialog"), device=true, condition=Device:hasFrontlight(),},
     toggle_frontlight = { category="none", event="ToggleFrontlight", title=_("Toggle frontlight"), device=true, condition=Device:hasFrontlight(),},
+    set_frontlight = { category="absolutenumber", event="SetFlIntensity", min=0, max=Device:getPowerDevice().fl_max, title=_("Set frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     increase_frontlight = { category="incrementalnumber", event="IncreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Increase frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
     decrease_frontlight = { category="incrementalnumber", event="DecreaseFlIntensity", min=1, max=Device:getPowerDevice().fl_max, title=_("Decrease frontlight brightness"), device=true, condition=Device:hasFrontlight(),},
+    set_frontlight_warmth = { category="absolutenumber", event="SetFlWarmth", min=0, max=100, title=_("Set frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     increase_frontlight_warmth = { category="incrementalnumber", event="IncreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Increase frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     decrease_frontlight_warmth = { category="incrementalnumber", event="DecreaseFlWarmth", min=1, max=Device:getPowerDevice().fl_warmth_max, title=_("Decrease frontlight warmth"), device=true, condition=Device:hasNaturalLight(),},
     toggle_gsensor = { category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:canToggleGSensor(),},
@@ -164,8 +166,10 @@ local dispatcher_menu_order = {
     "show_config_menu",
     "show_frontlight_dialog",
     "toggle_frontlight",
+    "set_frontlight",
     "increase_frontlight",
     "decrease_frontlight",
+    "set_frontlight_warmth",
     "increase_frontlight_warmth",
     "decrease_frontlight_warmth",
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -201,31 +201,12 @@ if Device:isAndroid() then
     local isAndroid, android = pcall(require, "android")
     if not isAndroid then return end
 
-    local logger = require("logger")
-    local powerd = Device:getPowerDevice()
-
-    local function FrontlightDialogWrapper( )
-        local usleep = require("ffi/util").usleep
-        android.settings.dialog(_("Frontlight settings"), _("Intensity"), _("Warmth"), _("Ok"))
-        logger.info("intensity: " .. powerd:frontlightIntensityHW())
-        repeat
-            usleep(75000) -- sleep 75ms before next check if dialog was quit
-        until (not android.isFrontlightDialogRunning())
-        logger.info("powerd.fl_intensity: " .. powerd.fl_intensity)
-        powerd:setIntensityHW(powerd:frontlightIntensityHW())
-        if android.isWarmthDevice~=nil and android.isWarmthDevice() then
-            powerd:setWarmth(powerd:getWarmth())
-            logger.info("powerd.fl_warmth: " .. powerd.fl_warmth)
-        end
-
-    end
-
-    -- on Android: overwrite generic frontlight with a native Dialog
+    -- overwrite generic frontlight with a native Dialog
     common_settings.frontlight = {
         text = _("Frontlight"),
         callback = function()
-            FrontlightDialogWrapper()
-            end,
+            Device:lightDialog()
+        end,
     }
 
     -- screen timeout options, disabled if device needs wakelocks.

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -201,6 +201,14 @@ if Device:isAndroid() then
     local isAndroid, android = pcall(require, "android")
     if not isAndroid then return end
 
+    -- on Android: overwrite generic frontlight with a native Dialog
+    common_settings.frontlight = {
+        text = _("Frontlight"),
+        callback = function()
+            android.settings.dialog(_("Frontlight settings"), _("Intensity"), _("Warmth"), _("Ok"))
+            end,
+    }
+
     -- screen timeout options, disabled if device needs wakelocks.
     common_settings.screen_timeout = require("ui/elements/screen_android"):getTimeoutMenuTable()
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -201,11 +201,30 @@ if Device:isAndroid() then
     local isAndroid, android = pcall(require, "android")
     if not isAndroid then return end
 
+    local logger = require("logger")
+    local powerd = Device:getPowerDevice()
+
+    local function FrontlightDialogWrapper( )
+        local usleep = require("ffi/util").usleep
+        android.settings.dialog(_("Frontlight settings"), _("Intensity"), _("Warmth"), _("Ok"))
+        logger.info("intensity: " .. powerd:frontlightIntensityHW())
+        repeat
+            usleep(75000) -- sleep 75ms before next check if dialog was quit
+        until (not android.isFrontlightDialogRunning())
+        logger.info("powerd.fl_intensity: " .. powerd.fl_intensity)
+        powerd:setIntensityHW(powerd:frontlightIntensityHW())
+        if android.isWarmthDevice~=nil and android.isWarmthDevice() then
+            powerd:setWarmth(powerd:getWarmth())
+            logger.info("powerd.fl_warmth: " .. powerd.fl_warmth)
+        end
+
+    end
+
     -- on Android: overwrite generic frontlight with a native Dialog
     common_settings.frontlight = {
         text = _("Frontlight"),
         callback = function()
-            android.settings.dialog(_("Frontlight settings"), _("Intensity"), _("Warmth"), _("Ok"))
+            FrontlightDialogWrapper()
             end,
     }
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -409,7 +409,7 @@ common_settings.document = {
                 local interval = G_reader_settings:readSetting("auto_save_settings_interval_minutes")
                 local s_interval
                 if interval == false then
-                    s_interval = "only on close"
+                    s_interval = _("only on close")
                 else
                     s_interval = T(N_("every 1 m", "every %1 m", interval), interval)
                 end

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -62,9 +62,11 @@ local order = {
     network = {
         "network_wifi",
         "network_proxy",
+        "network_powersave",
         "network_restore",
         "network_info",
         "network_before_wifi_action",
+        "network_after_wifi_action",
         "network_dismiss_scan",
         "----------------------------",
         "ssh",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -83,9 +83,11 @@ local order = {
     network = {
         "network_wifi",
         "network_proxy",
+        "network_powersave",
         "network_restore",
         "network_info",
         "network_before_wifi_action",
+        "network_after_wifi_action",
         "network_dismiss_scan",
         "----------------------------",
         "ssh",

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -420,7 +420,7 @@ end
 
 function NetworkMgr:getPowersaveMenuTable()
     return {
-        text = _("Kill Wi-Fi connection when inactive"),
+        text = _("Disable Wi-Fi connection when inactive"),
         help_text = _([[This will automatically turn Wi-Fi off after a generous period of network inactivity, without disrupting workflows that require a network connection, so you can just keep reading without worrying about battery drain.]]),
         checked_func = function() return G_reader_settings:isTrue("auto_disable_wifi") end,
         enabled_func = function() return Device:hasWifiManager() and not Device:isEmulator() end,

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -2,6 +2,7 @@ local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
+local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local LuaSettings = require("luasettings")
 local UIManager = require("ui/uimanager")
@@ -16,38 +17,80 @@ function NetworkMgr:readNWSettings()
     self.nw_settings = LuaSettings:open(DataStorage:getSettingsDir().."/network.lua")
 end
 
--- Used after restoreWifiAsync() to make sure we eventually send a NetworkConnected event, as a few things rely on it (KOSync, c.f. #5109).
-function NetworkMgr:connectivityCheck(iter)
-    -- Give up after a while...
-    if iter > 6 then
+-- Used after restoreWifiAsync() and the turn_on beforeWifiAction to make sure we eventually send a NetworkConnected event,
+-- as quite a few things rely on it (KOSync, c.f. #5109; the network activity check, c.f., #6424).
+function NetworkMgr:connectivityCheck(iter, callback, widget)
+    -- Give up after a while (restoreWifiAsync can take over 45s, so, try to cover that)...
+    if iter > 25 then
+        logger.info("Failed to restore Wi-Fi (after", iter, "iterations)!")
+        self.wifi_was_on = false
+        G_reader_settings:saveSetting("wifi_was_on", false)
+        -- If we abort, murder Wi-Fi and the async script first...
+        if Device:hasWifiManager() and not Device:isEmulator() then
+            os.execute("pkill -TERM restore-wifi-async.sh 2>/dev/null")
+        end
+        NetworkMgr:turnOffWifi()
+
+        -- Handle the UI warning if it's from a beforeWifiAction...
+        if widget then
+            UIManager:close(widget)
+            UIManager:show(InfoMessage:new{ text = _("Error connecting to the network") })
+        end
         return
     end
 
     if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
-        local Event = require("ui/event")
+        self.wifi_was_on = true
+        G_reader_settings:saveSetting("wifi_was_on", true)
         UIManager:broadcastEvent(Event:new("NetworkConnected"))
-        logger.info("WiFi successfully restored!")
+        logger.info("Wi-Fi successfully restored (after", iter, "iterations)!")
+
+        -- Handle the UI & callback if it's from a beforeWifiAction...
+        if widget then
+            UIManager:close(widget)
+        end
+        if callback then
+            callback()
+        else
+            -- If this trickled down from a turn_onbeforeWifiAction and there is no callback,
+            -- mention that the action needs to be retried manually.
+            if widget then
+                UIManager:show(InfoMessage:new{
+                    text = _("You can now retry the action that required network access"),
+                    timeout = 3,
+                })
+            end
+        end
     else
-        UIManager:scheduleIn(2, function() NetworkMgr:connectivityCheck(iter + 1) end)
+        UIManager:scheduleIn(2, function() NetworkMgr:connectivityCheck(iter + 1, callback, widget) end)
     end
 end
 
-function NetworkMgr:scheduleConnectivityCheck()
-    UIManager:scheduleIn(2, function() NetworkMgr:connectivityCheck(1) end)
+function NetworkMgr:scheduleConnectivityCheck(callback, widget)
+    UIManager:scheduleIn(2, function() NetworkMgr:connectivityCheck(1, callback, widget) end)
 end
 
 function NetworkMgr:init()
-    -- On Kobo, kill WiFi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
-    -- (i.e., if the launcher left the WiFi in an inconsistent state: modules loaded, but no route to gateway).
+    -- On Kobo, kill Wi-Fi if NetworkMgr:isWifiOn() and NOT NetworkMgr:isConnected()
+    -- (i.e., if the launcher left the Wi-Fi in an inconsistent state: modules loaded, but no route to gateway).
     if Device:isKobo() and self:isWifiOn() and not self:isConnected() then
-        logger.info("Kobo WiFi: Left in an inconsistent state by launcher!")
+        logger.info("Kobo Wi-Fi: Left in an inconsistent state by launcher!")
         self:turnOffWifi()
     end
 
     self.wifi_was_on = G_reader_settings:isTrue("wifi_was_on")
     if self.wifi_was_on and G_reader_settings:isTrue("auto_restore_wifi") then
-        self:restoreWifiAsync()
+        -- Don't bother if WiFi is already up...
+        if not (self:isWifiOn() and self:isConnected()) then
+            self:restoreWifiAsync()
+        end
         self:scheduleConnectivityCheck()
+    else
+        -- Trigger an initial NetworkConnected event if WiFi was already up when we were launched
+        if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
+            -- NOTE: This needs to be delayed because NetworkListener is initialized slightly later by the FM/Reader app...
+            UIManager:scheduleIn(2, function() UIManager:broadcastEvent(Event:new("NetworkConnected")) end)
+        end
     end
 end
 
@@ -57,6 +100,7 @@ end
 function NetworkMgr:turnOnWifi() end
 function NetworkMgr:turnOffWifi() end
 function NetworkMgr:isWifiOn() end
+function NetworkMgr:getNetworkInterfaceName() end
 function NetworkMgr:getNetworkList() end
 function NetworkMgr:getCurrentNetwork() end
 function NetworkMgr:authenticateNetwork() end
@@ -92,32 +136,69 @@ function NetworkMgr:promptWifiOff(complete_callback)
 end
 
 function NetworkMgr:turnOnWifiAndWaitForConnection(callback)
-    NetworkMgr:turnOnWifi()
-    local timeout = 30
-    local retry_count = 0
-    local info = InfoMessage:new{ text = T(_("Enabling Wi-Fi. Waiting for Internet connection…\nTimeout %1 seconds."), timeout)}
+    local info = InfoMessage:new{ text = _("Connecting to Wi-Fi…") }
     UIManager:show(info)
     UIManager:forceRePaint()
-    while not NetworkMgr:isOnline() and retry_count < timeout do
-        ffiutil.sleep(1)
-        retry_count = retry_count + 1
+
+    -- Don't bother if WiFi is already up...
+    if not (self:isWifiOn() and self:isConnected()) then
+        self:turnOnWifi()
     end
-    UIManager:close(info)
-    if retry_count == timeout then
-        UIManager:show(InfoMessage:new{ text = _("Error connecting to the network") })
-        return
-    end
-    if callback then callback() end
+
+    -- This will handle sending the proper Event, manage wifi_was_on, as well as tearing down Wi-Fi in case of failures,
+    -- (i.e., much like getWifiToggleMenuTable).
+    self:scheduleConnectivityCheck(callback, info)
 end
 
+--- This quirky internal flag is used for the rare beforeWifiAction -> afterWifiAction brackets.
+function NetworkMgr:clearBeforeActionFlag()
+    self._before_action_tripped = nil
+end
+
+function NetworkMgr:setBeforeActionFlag()
+    self._before_action_tripped = true
+end
+
+function NetworkMgr:getBeforeActionFlag()
+    return self._before_action_tripped
+end
+
+--- @note: The callback will only run *after* a *succesful* network connection.
+---        The only guarantee it provides is isConnected (i.e., an IP & a local gateway),
+---        *NOT* isOnline (i.e., WAN), se be careful with recursive callbacks!
 function NetworkMgr:beforeWifiAction(callback)
+    -- Remember that we ran, for afterWifiAction...
+    self:setBeforeActionFlag()
+
     local wifi_enable_action = G_reader_settings:readSetting("wifi_enable_action")
     if wifi_enable_action == "turn_on" then
         NetworkMgr:turnOnWifiAndWaitForConnection(callback)
     else
         NetworkMgr:promptWifiOn(callback)
     end
- end
+end
+
+-- NOTE: This is actually used very sparingly (newsdownloader/send2ebook),
+--       because bracketing a single action in a connect/disconnect session doesn't necessarily make much sense...
+function NetworkMgr:afterWifiAction(callback)
+    -- Don't do anything if beforeWifiAction never actually ran...
+    if not self:getBeforeActionFlag() then
+        return
+    end
+    self:clearBeforeActionFlag()
+
+    local wifi_disable_action = G_reader_settings:readSetting("wifi_disable_action")
+    if wifi_disable_action == "leave_on" then
+        -- NOP :)
+        if callback then
+           callback()
+        end
+    elseif wifi_disable_action == "turn_off" then
+        NetworkMgr:turnOffWifi(callback)
+    else
+        NetworkMgr:promptWifiOff(callback)
+    end
+end
 
 function NetworkMgr:isConnected()
     if Device:isAndroid() or Device:isCervantes() or Device:isPocketBook() or Device:isEmulator() then
@@ -174,6 +255,68 @@ function NetworkMgr:setHTTPProxy(proxy)
     end
 end
 
+-- Helper functions to hide the quirks of using beforeWifiAction properly ;).
+
+-- Run callback *now* if you're currently online (ie., isOnline),
+-- or attempt to go online and run it *ASAP* without any more user interaction.
+-- NOTE: If you're currently connected but without Internet access (i.e., isConnected and not isOnline),
+--       it will just attempt to re-connect, *without* running the callback.
+-- c.f., ReaderWikipedia:onShowWikipediaLookup @ frontend/apps/reader/modules/readerwikipedia.lua
+function NetworkMgr:runWhenOnline(callback)
+    if self:isOnline() then
+        callback()
+    else
+        --- @note: Avoid infinite recursion, beforeWifiAction only guarantees isConnected, not isOnline.
+        if not self:isConnected() then
+            self:beforeWifiAction(callback)
+        else
+            self:beforeWifiAction()
+        end
+    end
+end
+
+-- This one is for callbacks that only require isConnected, and since that's guaranteed by beforeWifiAction,
+-- you also have a guarantee that the callback *will* run.
+function NetworkMgr:runWhenConnected(callback)
+    if self:isConnected() then
+        callback()
+    else
+        self:beforeWifiAction(callback)
+    end
+end
+
+-- Mild variants that are used for recursive calls at the beginning of a complex function call.
+-- Returns true when not yet online, in which case you should *abort* (i.e., return) the initial call,
+-- and otherwise, go-on as planned.
+-- NOTE: If you're currently connected but without Internet access (i.e., isConnected and not isOnline),
+--       it will just attempt to re-connect, *without* running the callback.
+-- c.f., ReaderWikipedia:lookupWikipedia @ frontend/apps/reader/modules/readerwikipedia.lua
+function NetworkMgr:willRerunWhenOnline(callback)
+    if not self:isOnline() then
+        --- @note: Avoid infinite recursion, beforeWifiAction only guarantees isConnected, not isOnline.
+        if not self:isConnected() then
+            self:beforeWifiAction(callback)
+        else
+            self:beforeWifiAction()
+        end
+        return true
+    end
+
+    return false
+end
+
+-- This one is for callbacks that only require isConnected, and since that's guaranteed by beforeWifiAction,
+-- you also have a guarantee that the callback *will* run.
+function NetworkMgr:willRerunWhenConnected(callback)
+    if not self:isConnected() then
+        self:beforeWifiAction(callback)
+        return true
+    end
+
+    return false
+end
+
+
 function NetworkMgr:getWifiMenuTable()
     if Device:isAndroid() then
         return {
@@ -196,7 +339,6 @@ function NetworkMgr:getWifiToggleMenuTable()
             local complete_callback = function()
                 -- notify touch menu to update item check state
                 touchmenu_instance:updateItems()
-                local Event = require("ui/event")
                 -- if wifi was on, this callback will only be executed when the network has been
                 -- disconnected.
                 if wifi_status then
@@ -208,7 +350,7 @@ function NetworkMgr:getWifiToggleMenuTable()
                         if NetworkMgr:isWifiOn() and NetworkMgr:isConnected() then
                             UIManager:broadcastEvent(Event:new("NetworkConnected"))
                         elseif NetworkMgr:isWifiOn() and not NetworkMgr:isConnected() then
-                            -- Don't leave WiFi in an inconsistent state if the connection failed.
+                            -- Don't leave Wi-Fi in an inconsistent state if the connection failed.
                             self.wifi_was_on = false
                             G_reader_settings:saveSetting("wifi_was_on", false)
                             -- NOTE: We're limiting this to only a few platforms, as it might be actually harmful on some devices.
@@ -219,8 +361,8 @@ function NetworkMgr:getWifiToggleMenuTable()
                             --       Kobo: Yes, please.
                             --       Cervantes: Loads/unloads module, probably could use it like Kobo.
                             --       Kindle: Probably could use it, if only because leaving Wireless on is generally a terrible idea on Kindle,
-                            --               except that we defer to lipc, which makes WiFi handling asynchronous, and the callback is simply delayed by 1s,
-                            --               so we can't be sure the system will actually have finished bringing WiFi up by then...
+                            --               except that we defer to lipc, which makes Wi-Fi handling asynchronous, and the callback is simply delayed by 1s,
+                            --               so we can't be sure the system will actually have finished bringing Wi-Fi up by then...
                             NetworkMgr:turnOffWifi()
                             touchmenu_instance:updateItems()
                         end
@@ -276,9 +418,26 @@ function NetworkMgr:getProxyMenuTable()
     }
 end
 
+function NetworkMgr:getPowersaveMenuTable()
+    return {
+        text = _("Kill Wi-Fi connection when inactive"),
+        help_text = _([[This will automatically turn Wi-Fi off after a generous period of network inactivity, without disrupting workflows that require a network connection, so you can just keep reading without worrying about battery drain.]]),
+        checked_func = function() return G_reader_settings:isTrue("auto_disable_wifi") end,
+        enabled_func = function() return Device:hasWifiManager() and not Device:isEmulator() end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("auto_disable_wifi")
+            -- NOTE: Well, not exactly, but the activity check wouldn't be (un)scheduled until the next Network(Dis)Connected event...
+            UIManager:show(InfoMessage:new{
+                text = _("This will take effect on next restart."),
+            })
+        end,
+    }
+end
+
 function NetworkMgr:getRestoreMenuTable()
     return {
-        text = _("Automatically restore Wi-Fi connection after resume"),
+        text = _("Restore Wi-Fi connection on resume"),
+        help_text = _([[This will attempt to automatically and silently re-connect to Wi-Fi on startup or on resume if Wi-Fi used to be enabled the last time you used KOReader.]]),
         checked_func = function() return G_reader_settings:isTrue("auto_restore_wifi") end,
         enabled_func = function() return Device:hasWifiManager() and not Device:isEmulator() end,
         callback = function() G_reader_settings:flipNilOrFalse("auto_restore_wifi") end,
@@ -306,34 +465,67 @@ function NetworkMgr:getInfoMenuTable()
 end
 
 function NetworkMgr:getBeforeWifiActionMenuTable()
-   local wifi_enable_action_setting = G_reader_settings:readSetting("wifi_enable_action") or "prompt"
-   local wifi_enable_actions = {
-       turn_on = {_("turn on"), _("Turn on (experimental)")},
-       prompt = {_("prompt"), _("Prompt")},
-   }
-   local action_table = function(wifi_enable_action)
-       return {
-           text = wifi_enable_actions[wifi_enable_action][2],
-           checked_func = function()
-               return wifi_enable_action_setting == wifi_enable_action
-           end,
-           callback = function()
-               wifi_enable_action_setting = wifi_enable_action
-               G_reader_settings:saveSetting("wifi_enable_action", wifi_enable_action)
-           end,
-       }
-   end
-   return {
-       text_func = function()
-           return T(_("Action when Wi-Fi is off: %1"),
-               wifi_enable_actions[wifi_enable_action_setting][1]
-           )
-       end,
-       sub_item_table = {
-           action_table("turn_on"),
-           action_table("prompt"),
-       }
-   }
+    local wifi_enable_action_setting = G_reader_settings:readSetting("wifi_enable_action") or "prompt"
+    local wifi_enable_actions = {
+        turn_on = {_("turn on"), _("Turn on")},
+        prompt = {_("prompt"), _("Prompt")},
+    }
+    local action_table = function(wifi_enable_action)
+    return {
+        text = wifi_enable_actions[wifi_enable_action][2],
+        checked_func = function()
+            return wifi_enable_action_setting == wifi_enable_action
+        end,
+        callback = function()
+            wifi_enable_action_setting = wifi_enable_action
+            G_reader_settings:saveSetting("wifi_enable_action", wifi_enable_action)
+        end,
+    }
+    end
+    return {
+        text_func = function()
+            return T(_("Action when Wi-Fi is off: %1"),
+                wifi_enable_actions[wifi_enable_action_setting][1]
+            )
+        end,
+        sub_item_table = {
+            action_table("turn_on"),
+            action_table("prompt"),
+        }
+    }
+end
+
+function NetworkMgr:getAfterWifiActionMenuTable()
+    local wifi_disable_action_setting = G_reader_settings:readSetting("wifi_disable_action") or "prompt"
+    local wifi_disable_actions = {
+        leave_on = {_("leave on"), _("Leave on")},
+        turn_off = {_("turn off"), _("Turn off")},
+        prompt = {_("prompt"), _("Prompt")},
+    }
+    local action_table = function(wifi_disable_action)
+    return {
+        text = wifi_disable_actions[wifi_disable_action][2],
+        checked_func = function()
+            return wifi_disable_action_setting == wifi_disable_action
+        end,
+        callback = function()
+            wifi_disable_action_setting = wifi_disable_action
+            G_reader_settings:saveSetting("wifi_disable_action", wifi_disable_action)
+        end,
+    }
+    end
+    return {
+        text_func = function()
+            return T(_("Action when done with Wi-Fi: %1"),
+                wifi_disable_actions[wifi_disable_action_setting][1]
+            )
+        end,
+        sub_item_table = {
+            action_table("leave_on"),
+            action_table("turn_off"),
+            action_table("prompt"),
+        }
+    }
 end
 
 function NetworkMgr:getDismissScanMenuTable()
@@ -354,9 +546,11 @@ function NetworkMgr:getMenuTable(common_settings)
     common_settings.network_info = self:getInfoMenuTable()
 
     if Device:hasWifiManager() then
+        common_settings.network_powersave = self:getPowersaveMenuTable()
         common_settings.network_restore = self:getRestoreMenuTable()
         common_settings.network_dismiss_scan = self:getDismissScanMenuTable()
         common_settings.network_before_wifi_action = self:getBeforeWifiActionMenuTable()
+        common_settings.network_after_wifi_action = self:getAfterWifiActionMenuTable()
     end
 end
 
@@ -457,6 +651,7 @@ end
 if NETWORK_PROXY then
     NetworkMgr:setHTTPProxy(NETWORK_PROXY)
 end
+
 
 Device:initNetworkManager(NetworkMgr)
 NetworkMgr:init()

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -140,18 +140,21 @@ function NetworkListener:_scheduleActivityCheck()
 
     local tx_packets = NetworkListener:_getTxPackets()
     if self._last_tx_packets then
-        -- Compute noise margin based on the current delay
+        -- Compute noise threshold based on the current delay
         local delay = self._activity_check_delay or default_network_timeout_seconds
-        local noise = delay / default_network_timeout_seconds * network_activity_noise_margin
+        local noise_threshold = delay / default_network_timeout_seconds * network_activity_noise_margin
+        local delta = tx_packets - self._last_tx_packets
         -- If there was no meaningful activity (+/- a couple packets), kill the Wi-Fi
-        if math.max(0, tx_packets - noise) <= self._last_tx_packets then
-            logger.dbg("NetworkListener: No meaningful network activity ( then:", self._last_tx_packets, "vs. now:", tx_packets, "), disabling Wi-Fi")
+        if delta <= noise_threshold then
+            logger.dbg("NetworkListener: No meaningful network activity (delta:", delta, "<= threshold:", noise_threshold, "[ then:", self._last_tx_packets, "vs. now:", tx_packets, "]) -> disabling Wi-Fi")
             keep_checking = false
             local complete_callback = function()
                 UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
             end
             NetworkMgr:turnOffWifi(complete_callback)
             -- NOTE: We leave wifi_was_on as-is on purpose, we wouldn't want to break auto_restore_wifi workflows on the next start...
+        else
+            logger.dbg("NetworkListener: Significant network activity (delta:", delta, "> threshold:", noise_threshold, "[ then:", self._last_tx_packets, "vs. now:", tx_packets, "]) -> keeping Wi-Fi enabled")
         end
     end
 

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -155,26 +155,28 @@ function NetworkListener:_scheduleActivityCheck()
         end
     end
 
-    -- If we've just killed Wi-Fi, onNetworkDisconnected will take care of unscheduling us
-    if keep_checking then
-        -- Update tracker for next iter
-        self._last_tx_packets = tx_packets
-
-        -- If it's already been scheduled, increase the delay until we hit the ceiling
-        if self._activity_check_delay then
-            self._activity_check_delay = self._activity_check_delay + default_network_timeout_seconds
-
-            if self._activity_check_delay > max_network_timeout_seconds then
-                self._activity_check_delay = max_network_timeout_seconds
-            end
-        else
-            self._activity_check_delay = default_network_timeout_seconds
-        end
-
-        UIManager:scheduleIn(self._activity_check_delay, self._scheduleActivityCheck, self)
-        self._activity_check_scheduled = true
-        logger.dbg("NetworkListener: network activity check scheduled in", self._activity_check_delay, "seconds")
+    -- If we've just killed Wi-Fi, onNetworkDisconnected will take care of unscheduling us, so we're done
+    if not keep_checking then
+        return
     end
+
+    -- Update tracker for next iter
+    self._last_tx_packets = tx_packets
+
+    -- If it's already been scheduled, increase the delay until we hit the ceiling
+    if self._activity_check_delay then
+        self._activity_check_delay = self._activity_check_delay + default_network_timeout_seconds
+
+        if self._activity_check_delay > max_network_timeout_seconds then
+            self._activity_check_delay = max_network_timeout_seconds
+        end
+    else
+        self._activity_check_delay = default_network_timeout_seconds
+    end
+
+    UIManager:scheduleIn(self._activity_check_delay, self._scheduleActivityCheck, self)
+    self._activity_check_scheduled = true
+    logger.dbg("NetworkListener: network activity check scheduled in", self._activity_check_delay, "seconds")
 end
 
 function NetworkListener:onNetworkConnected()

--- a/frontend/ui/network/networklistener.lua
+++ b/frontend/ui/network/networklistener.lua
@@ -1,8 +1,11 @@
 local BD = require("ui/bidi")
+local Device = require("device")
+local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local NetworkMgr = require("ui/network/manager")
 local UIManager = require("ui/uimanager")
+local logger = require("logger")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
@@ -16,10 +19,17 @@ function NetworkListener:onToggleWifi()
         })
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
-        -- This is specifically the toggle wifi action, so consent is implied.
-        NetworkMgr:turnOnWifi()
+        -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
+        -- This is specifically the toggle Wi-Fi action, so consent is implied.
+        local complete_callback = function()
+            UIManager:broadcastEvent(Event:new("NetworkConnected"))
+        end
+        NetworkMgr:turnOnWifi(complete_callback)
     else
-        NetworkMgr:turnOffWifi()
+        local complete_callback = function()
+            UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
+        end
+        NetworkMgr:turnOffWifi(complete_callback)
 
         UIManager:show(InfoMessage:new{
             text = _("Wi-Fi off."),
@@ -29,8 +39,11 @@ function NetworkListener:onToggleWifi()
 end
 
 function NetworkListener:onInfoWifiOff()
-    -- can't hurt
-    NetworkMgr:turnOffWifi()
+    -- That's the end goal
+    local complete_callback = function()
+        UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
+    end
+    NetworkMgr:turnOffWifi(complete_callback)
 
     UIManager:show(InfoMessage:new{
         text = _("Wi-Fi off."),
@@ -46,8 +59,12 @@ function NetworkListener:onInfoWifiOn()
         })
 
         -- NB Normal widgets should use NetworkMgr:promptWifiOn()
+        -- (or, better yet, the NetworkMgr:beforeWifiAction wrappers: NetworkMgr:runWhenOnline() & co.)
         -- This is specifically the toggle Wi-Fi action, so consent is implied.
-        NetworkMgr:turnOnWifi()
+        local complete_callback = function()
+            UIManager:broadcastEvent(Event:new("NetworkConnected"))
+        end
+        NetworkMgr:turnOnWifi(complete_callback)
     else
         local info_text
         local current_network = NetworkMgr:getCurrentNetwork()
@@ -63,5 +80,137 @@ function NetworkListener:onInfoWifiOn()
         })
     end
 end
+
+-- Everything below is to handle auto_disable_wifi ;).
+local default_network_timeout_seconds = 5*60
+local max_network_timeout_seconds = 30*60
+-- This should be more than enough to catch actual activity vs. noise spread over 5 minutes.
+local network_activity_noise_margin = 12 -- unscaled_size_check: ignore
+
+-- Read the statistics/tx_packets sysfs entry for the current network interface.
+-- It *should* be the least noisy entry on an idle network...
+-- The fact that auto_disable_wifi is only available on (Device:hasWifiManager() and not Device:isEmulator())
+-- allows us to get away with a Linux-only solution.
+function NetworkListener:_getTxPackets()
+    -- read tx_packets stats from sysfs (for the right network if)
+    local file = io.open("/sys/class/net/" .. NetworkMgr:getNetworkInterfaceName() .. "/statistics/tx_packets", "rb")
+
+    -- file exists only when Wi-Fi module is loaded.
+    if not file then return nil end
+
+    local out = file:read("*all")
+    file:close()
+
+    -- strip NaN from file read (i.e.,: line endings, error messages)
+    local tx_packets
+    if type(out) ~= "number" then
+        tx_packets = tonumber(out)
+    else
+        tx_packets = out
+    end
+
+    -- finally return it
+    if type(tx_packets) == "number" then
+        return tx_packets
+    else
+        return nil
+    end
+end
+
+function NetworkListener:_unscheduleActivityCheck()
+    logger.dbg("NetworkListener: unschedule network activity check")
+    if self._activity_check_scheduled then
+        UIManager:unschedule(self._scheduleActivityCheck)
+        self._activity_check_scheduled = nil
+        logger.dbg("NetworkListener: network activity check unscheduled")
+    end
+
+    -- We also need to reset the stats, otherwise we'll be comparing apples vs. oranges... (i.e., two different network sessions)
+    if self._last_tx_packets then
+        self._last_tx_packets = nil
+    end
+    if self._activity_check_delay then
+        self._activity_check_delay = nil
+    end
+end
+
+function NetworkListener:_scheduleActivityCheck()
+    logger.dbg("NetworkListener: network activity check")
+    local keep_checking = true
+
+    local tx_packets = NetworkListener:_getTxPackets()
+    if self._last_tx_packets then
+        -- Compute noise margin based on the current delay
+        local delay = self._activity_check_delay or default_network_timeout_seconds
+        local noise = delay / default_network_timeout_seconds * network_activity_noise_margin
+        -- If there was no meaningful activity (+/- a couple packets), kill the Wi-Fi
+        if math.max(0, tx_packets - noise) <= self._last_tx_packets then
+            logger.dbg("NetworkListener: No meaningful network activity ( then:", self._last_tx_packets, "vs. now:", tx_packets, "), disabling Wi-Fi")
+            keep_checking = false
+            local complete_callback = function()
+                UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
+            end
+            NetworkMgr:turnOffWifi(complete_callback)
+            -- NOTE: We leave wifi_was_on as-is on purpose, we wouldn't want to break auto_restore_wifi workflows on the next start...
+        end
+    end
+
+    -- If we've just killed Wi-Fi, onNetworkDisconnected will take care of unscheduling us
+    if keep_checking then
+        -- Update tracker for next iter
+        self._last_tx_packets = tx_packets
+
+        -- If it's already been scheduled, increase the delay until we hit the ceiling
+        if self._activity_check_delay then
+            self._activity_check_delay = self._activity_check_delay + default_network_timeout_seconds
+
+            if self._activity_check_delay > max_network_timeout_seconds then
+                self._activity_check_delay = max_network_timeout_seconds
+            end
+        else
+            self._activity_check_delay = default_network_timeout_seconds
+        end
+
+        UIManager:scheduleIn(self._activity_check_delay, self._scheduleActivityCheck, self)
+        self._activity_check_scheduled = true
+        logger.dbg("NetworkListener: network activity check scheduled in", self._activity_check_delay, "seconds")
+    end
+end
+
+function NetworkListener:onNetworkConnected()
+    if not (Device:hasWifiManager() and not Device:isEmulator()) then
+        return
+    end
+
+    if not G_reader_settings:isTrue("auto_disable_wifi") then
+        return
+    end
+
+    -- If the activity check has already been scheduled for some reason, unschedule it first.
+    NetworkListener:_unscheduleActivityCheck()
+
+    NetworkListener:_scheduleActivityCheck()
+end
+
+function NetworkListener:onNetworkDisconnected()
+    if not (Device:hasWifiManager() and not Device:isEmulator()) then
+        return
+    end
+
+    if not G_reader_settings:isTrue("auto_disable_wifi") then
+        return
+    end
+
+    NetworkListener:_unscheduleActivityCheck()
+
+    -- Reset NetworkMgr's beforeWifiAction marker
+    NetworkMgr:clearBeforeActionFlag()
+end
+
+-- Also unschedule on suspend (and we happen to also kill Wi-Fi to do so, so resetting the stats is also relevant here)
+function NetworkListener:onSuspend()
+    self:onNetworkDisconnected()
+end
+
 
 return NetworkListener

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -455,21 +455,19 @@ function OTAManager:getOTAMenuTable()
     return {
         text = _("Update"),
         hold_callback = function()
-            if not NetworkMgr:isOnline() then
-                NetworkMgr:promptWifiOn()
-            else
+            local connect_callback = function()
                 OTAManager:fetchAndProcessUpdate()
             end
+            NetworkMgr:runWhenOnline(connect_callback)
         end,
         sub_item_table = {
             {
                 text = _("Check for update"),
                 callback = function()
-                    if not NetworkMgr:isOnline() then
-                        NetworkMgr:promptWifiOn()
-                    else
+                    local connect_callback = function()
                         OTAManager:fetchAndProcessUpdate()
                     end
+                    NetworkMgr:runWhenOnline(connect_callback)
                 end
             },
             {

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -416,10 +416,10 @@ Show translated text in TextViewer, with alternate translations
 --]]
 function Translator:showTranslation(text, target_lang, source_lang)
     local NetworkMgr = require("ui/network/manager")
-    if not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
+    if NetworkMgr:willRerunWhenOnline(function() self:showTranslation(text, target_lang, source_lang) end) then
         return
     end
+
     -- Wrap next function with Trapper to be able to interrupt
     -- translation service query.
     local Trapper = require("ui/trapper")

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -997,12 +997,17 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
             if direction == "-" then
                 value = self.configurable[name] or values[1]
                 if type(value) == "table" then
+                    -- Don't update directly this table: it might be a reference
+                    -- to one of the original preset values tables
+                    local updated = {}
                     for i=1, #value do
-                        value[i] = value[i] - 1
-                        if value[i] < 0 then
-                            value[i] = 0
+                        local v = value[i] - 1
+                        if v < 0 then
+                            v = 0
                         end
+                        table.insert(updated, v)
                     end
+                    value = updated
                 else
                     value = value - 1
                     if value < 0 then
@@ -1012,9 +1017,11 @@ function ConfigDialog:onConfigFineTuneChoose(values, name, event, args, events, 
             else
                 value = self.configurable[name] or values[#values]
                 if type(value) == "table" then
+                    local updated = {}
                     for i=1, #value do
-                        value[i] = value[i] + 1
+                        table.insert(updated, value[i] + 1)
                     end
+                    value = updated
                 else
                     value = value + 1
                 end

--- a/frontend/ui/widget/networksetting.lua
+++ b/frontend/ui/widget/networksetting.lua
@@ -22,9 +22,12 @@ Example:
     UIManager:show(require("ui/widget/networksetting"):new{
         network_list = network_list,
         connect_callback = function()
-            -- connect_callback will be called when an connect/disconnect
-            -- attempt has been made. you can update UI widgets in the
-            -- callback.
+            -- connect_callback will be called when a *connect* (NOT disconnect)
+            -- attempt has been successful.
+            -- You can update UI widgets in the callback.
+        end,
+        disconnect_callback = function()
+            -- This one will fire unconditionally after a disconnect attempt.
         end,
     })
 
@@ -224,7 +227,8 @@ function NetworkItem:connect()
         text = err_msg
     end
 
-    if self.setting_ui.connect_callback then
+    -- Do what it says on the tin, and only trigger the connect_callback on a *successful* connect.
+    if success and self.setting_ui.connect_callback then
         self.setting_ui.connect_callback()
     end
 
@@ -244,8 +248,8 @@ function NetworkItem:disconnect()
     self.info.connected = nil
     self:refresh()
     self.setting_ui:setConnectedItem(nil)
-    if self.setting_ui.connect_callback then
-        self.setting_ui.connect_callback()
+    if self.setting_ui.disconnect_callback then
+        self.setting_ui.disconnect_callback()
     end
 end
 
@@ -378,6 +382,7 @@ local NetworkSetting = InputContainer:new{
     -- }
     network_list = nil,
     connect_callback = nil,
+    disconnect_callback = nil,
 }
 
 function NetworkSetting:init()

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -53,6 +53,7 @@ local OPDSBrowser = Menu:extend{
         ["text/plain"] = "TXT",
         ["application/x-mobipocket-ebook"] = "MOBI",
         ["application/x-mobi8-ebook"] = "AZW3",
+        ["application/vnd.amazon.mobi8-ebook"] = "AZW3",
         ["application/x-cbz"] = "CBZ",
         ["application/vnd.comicbook+zip"] = "CBZ",
         ["application/zip"] = "CBZ",
@@ -61,6 +62,8 @@ local OPDSBrowser = Menu:extend{
         ["application/x-rar-compressed"] = "CBR",
         ["application/vnd.rar"] = "CBR",
         ["application/djvu"] = "DJVU",
+        ["image/x-djvu"] = "DJVU",
+        ["image/vnd.djvu"] = "DJVU",
     },
 
     width = Screen:getWidth(),

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -54,7 +54,12 @@ local OPDSBrowser = Menu:extend{
         ["application/x-mobipocket-ebook"] = "MOBI",
         ["application/x-mobi8-ebook"] = "AZW3",
         ["application/x-cbz"] = "CBZ",
+        ["application/vnd.comicbook+zip"] = "CBZ",
+        ["application/zip"] = "CBZ",
         ["application/x-cbr"] = "CBR",
+        ["application/vnd.comicbook-rar"] = "CBR",
+        ["application/x-rar-compressed"] = "CBR",
+        ["application/vnd.rar"] = "CBR",
         ["application/djvu"] = "DJVU",
     },
 

--- a/frontend/ui/widget/opdsbrowser.lua
+++ b/frontend/ui/widget/opdsbrowser.lua
@@ -377,10 +377,7 @@ end
 
 function OPDSBrowser:getCatalog(item_url, username, password)
     local ok, catalog = pcall(self.parseFeed, self, item_url, username, password)
-    if not ok and catalog and not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
-        return
-    elseif not ok and catalog then
+    if not ok and catalog then
         logger.info("cannot get catalog info from", item_url, catalog)
         UIManager:show(InfoMessage:new{
             text = T(_("Cannot get catalog info from %1"), (BD.url(item_url) or "")),
@@ -724,11 +721,17 @@ function OPDSBrowser:onMenuSelect(item)
         self:showDownloads(item)
     -- navigation
     else
+        local connect_callback
         if item.searchable then
-            self:browseSearchable(item.url, item.username, item.password)
+            connect_callback = function()
+                self:browseSearchable(item.url, item.username, item.password)
+            end
         else
-            self:browse(item.url, item.username, item.password)
+            connect_callback = function()
+                self:browse(item.url, item.username, item.password)
+            end
         end
+        NetworkMgr:runWhenConnected(connect_callback)
     end
     return true
 end

--- a/platform/cervantes/restore-wifi-async.sh
+++ b/platform/cervantes/restore-wifi-async.sh
@@ -21,11 +21,11 @@ EOF
 }
 
 RestoreWifi() {
-    echo "[$(date)] restore-wifi-async.sh: Restarting WiFi"
+    echo "[$(date)] restore-wifi-async.sh: Restarting Wi-Fi"
     ./enable-wifi.sh
     RunWpaCli
     ./obtain-ip.sh
-    echo "[$(date)] restore-wifi-async.sh: Restarted WiFi"
+    echo "[$(date)] restore-wifi-async.sh: Restarted Wi-Fi"
 }
 
 RestoreWifi &

--- a/platform/kobo/disable-wifi.sh
+++ b/platform/kobo/disable-wifi.sh
@@ -14,6 +14,7 @@ fi
 
 # NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
 #       so we have to wait for udhcpc to die ourselves...
+# NOTE: But if all is well, there *isn't* any udhcpc process or script left to begin with...
 kill_timeout=0
 while pkill -0 udhcpc; do
     # Stop waiting after 5s

--- a/platform/kobo/disable-wifi.sh
+++ b/platform/kobo/disable-wifi.sh
@@ -1,8 +1,38 @@
 #!/bin/sh
 
 # Disable wifi, and remove all modules.
+# NOTE: Save our resolv.conf to avoid ending up with an empty one, in case the DHCP client wipes it on release (#6424).
+cp -a "/etc/resolv.conf" "/tmp/resolv.ko"
+old_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
 
-killall udhcpc default.script wpa_supplicant 2>/dev/null
+if [ -x "/sbin/dhcpcd" ]; then
+    env -u LD_LIBRARY_PATH dhcpcd -d -k "${INTERFACE}"
+    killall -q -TERM udhcpc default.script
+else
+    killall -q -TERM udhcpc default.script dhcpcd
+fi
+
+# NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
+#       so we have to wait for udhcpc to die ourselves...
+kill_timeout=0
+while pkill -0 udhcpc; do
+    # Stop waiting after 5s
+    if [ ${kill_timeout} -ge 20 ]; then
+        break
+    fi
+    usleep 250000
+    kill_timeout=$((kill_timeout + 1))
+done
+
+new_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
+# Restore our network-specific resolv.conf if the DHCP client wiped it when releasing the lease...
+if [ "${new_hash}" != "${old_hash}" ]; then
+    mv -f "/tmp/resolv.ko" "/etc/resolv.conf"
+else
+    rm -f "/tmp/resolv.ko"
+fi
+
+wpa_cli terminate
 
 [ "${WIFI_MODULE}" != "8189fs" ] && [ "${WIFI_MODULE}" != "8192es" ] && wlarm_le -i "${INTERFACE}" down
 ifconfig "${INTERFACE}" down

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # Load wifi modules and enable wifi.
-
 lsmod | grep -q sdio_wifi_pwr || insmod "/drivers/${PLATFORM}/wifi/sdio_wifi_pwr.ko"
 # Moar sleep!
 usleep 250000
@@ -13,6 +12,6 @@ sleep 1
 ifconfig "${INTERFACE}" up
 [ "${WIFI_MODULE}" != "8189fs" ] && [ "${WIFI_MODULE}" != "8192es" ] && wlarm_le -i "${INTERFACE}" up
 
-pidof wpa_supplicant >/dev/null ||
+pkill -0 wpa_supplicant ||
     env -u LD_LIBRARY_PATH \
-        wpa_supplicant -D wext -s -i "${INTERFACE}" -O /var/run/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -B
+        wpa_supplicant -D wext -s -i "${INTERFACE}" -c /etc/wpa_supplicant/wpa_supplicant.conf -O /var/run/wpa_supplicant -B

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -115,6 +115,19 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     #       A SIGTERM does not break anything, it'll just prevent automatic lease renewal until the time
     #       KOReader actually sets the if up itself (i.e., it'll do)...
     killall -q -TERM nickel hindenburg sickel fickel adobehost dhcpcd-dbus dhcpcd fmon
+
+    # Wait for Nickel to die... (oh, procps with killall -w, how I miss you...)
+    kill_timeout=0
+    while pkill -0 nickel; do
+        # Stop waiting after 4s
+        if [ ${kill_timeout} -ge 15 ]; then
+            break
+        fi
+        usleep 250000
+        kill_timeout=$((kill_timeout + 1))
+    done
+    # Remove Nickel's FIFO to avoid udev & udhcpc scripts hanging on open() on it...
+    rm -f /tmp/nickel-hardware-status
 fi
 
 # fallback for old fmon, KFMon and advboot users (-> if no args were passed to the script, start the FM)

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -35,6 +35,7 @@ if lsmod | grep -q sdio_wifi_pwr; then
     fi
     # NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
     #       so we have to wait for udhcpc to die ourselves...
+    # NOTE: But if all is well, there *isn't* any udhcpc process or script left to begin with...
     kill_timeout=0
     while pkill -0 udhcpc; do
         # Stop waiting after 5s

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -21,10 +21,38 @@ unset KO_NO_CBB
     /etc/init.d/on-animator.sh
 ) &
 
-# Make sure we kill the WiFi first, because nickel apparently doesn't like it if it's up... (cf. #1520)
+# Make sure we kill the Wi-Fi first, because nickel apparently doesn't like it if it's up... (cf. #1520)
 # NOTE: That check is possibly wrong on PLATFORM == freescale (because I don't know if the sdio_wifi_pwr module exists there), but we don't terribly care about that.
 if lsmod | grep -q sdio_wifi_pwr; then
-    killall restore-wifi-async.sh enable-wifi.sh obtain-ip.sh udhcpc default.script wpa_supplicant 2>/dev/null
+    killall -q -TERM restore-wifi-async.sh enable-wifi.sh obtain-ip.sh
+    cp -a "/etc/resolv.conf" "/tmp/resolv.ko"
+    old_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
+    if [ -x "/sbin/dhcpcd" ]; then
+        env -u LD_LIBRARY_PATH dhcpcd -d -k "${INTERFACE}"
+        killall -q -TERM udhcpc default.script
+    else
+        killall -q -TERM udhcpc default.script dhcpcd
+    fi
+    # NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
+    #       so we have to wait for udhcpc to die ourselves...
+    kill_timeout=0
+    while pkill -0 udhcpc; do
+        # Stop waiting after 5s
+        if [ ${kill_timeout} -ge 20 ]; then
+            break
+        fi
+        usleep 250000
+        kill_timeout=$((kill_timeout + 1))
+    done
+
+    new_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
+    # Restore our network-specific resolv.conf if the DHCP client wiped it when releasing the lease...
+    if [ "${new_hash}" != "${old_hash}" ]; then
+        mv -f "/tmp/resolv.ko" "/etc/resolv.conf"
+    else
+        rm -f "/tmp/resolv.ko"
+    fi
+    wpa_cli terminate
     [ "${WIFI_MODULE}" != "8189fs" ] && [ "${WIFI_MODULE}" != "8192es" ] && wlarm_le -i "${INTERFACE}" down
     ifconfig "${INTERFACE}" down
     # NOTE: Kobo's busybox build is weird. rmmod appears to be modprobe in disguise, defaulting to the -r flag...

--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -2,5 +2,10 @@
 
 ./release-ip.sh
 
-# Use udhcpc to obtain IP.
-env -u LD_LIBRARY_PATH udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -t15 -T10 -A3 -b -q
+# NOTE: Prefer dhcpcd over udhcpc if available. That's what Nickel uses,
+#       and udhcpc appears to trip some insanely wonky corner cases on current FW (#6421)
+if [ -x "/sbin/dhcpcd" ]; then
+    env -u LD_LIBRARY_PATH dhcpcd -d -t 30 -w "${INTERFACE}"
+else
+    env -u LD_LIBRARY_PATH udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -b -q
+fi

--- a/platform/kobo/release-ip.sh
+++ b/platform/kobo/release-ip.sh
@@ -15,6 +15,7 @@ fi
 
 # NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
 #       so we have to wait for udhcpc to die ourselves...
+# NOTE: But if all is well, there *isn't* any udhcpc process or script left to begin with...
 kill_timeout=0
 while pkill -0 udhcpc; do
     # Stop waiting after 5s

--- a/platform/kobo/release-ip.sh
+++ b/platform/kobo/release-ip.sh
@@ -1,8 +1,34 @@
 #!/bin/sh
 
-# PATH export is only needed if you run this script manually from a shell
-export PATH="${PATH}:/sbin"
-
 # Release IP and shutdown udhcpc.
-pkill -9 -f '/bin/sh /etc/udhcpc.d/default.script'
-ifconfig "${INTERFACE}" 0.0.0.0
+# NOTE: Save our resolv.conf to avoid ending up with an empty one, in case the DHCP client wipes it on release (#6424).
+cp -a "/etc/resolv.conf" "/tmp/resolv.ko"
+old_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
+
+if [ -x "/sbin/dhcpcd" ]; then
+    env -u LD_LIBRARY_PATH dhcpcd -d -k "${INTERFACE}"
+    killall -q -TERM udhcpc default.script
+else
+    killall -q -TERM udhcpc default.script dhcpcd
+    ifconfig "${INTERFACE}" 0.0.0.0
+fi
+
+# NOTE: dhcpcd -k waits for the signalled process to die, but busybox's killall doesn't have a -w, --wait flag,
+#       so we have to wait for udhcpc to die ourselves...
+kill_timeout=0
+while pkill -0 udhcpc; do
+    # Stop waiting after 5s
+    if [ ${kill_timeout} -ge 20 ]; then
+        break
+    fi
+    usleep 250000
+    kill_timeout=$((kill_timeout + 1))
+done
+
+new_hash="$(md5sum "/etc/resolv.conf" | cut -f1 -d' ')"
+# Restore our network-specific resolv.conf if the DHCP client wiped it when releasing the lease...
+if [ "${new_hash}" != "${old_hash}" ]; then
+    mv -f "/tmp/resolv.ko" "/etc/resolv.conf"
+else
+    rm -f "/tmp/resolv.ko"
+fi

--- a/platform/kobo/restore-wifi-async.sh
+++ b/platform/kobo/restore-wifi-async.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 RestoreWifi() {
-    echo "[$(date)] restore-wifi-async.sh: Restarting WiFi"
+    echo "[$(date)] restore-wifi-async.sh: Restarting Wi-Fi"
 
     ./enable-wifi.sh
 
@@ -9,8 +9,8 @@ RestoreWifi() {
     # Pilfered from https://github.com/shermp/Kobo-UNCaGED/pull/21 ;)
     wpac_timeout=0
     while ! wpa_cli status | grep -q "wpa_state=COMPLETED"; do
-        # If wpa_supplicant hasn't connected within 10 seconds, assume it never will, and tear down WiFi
-        if [ ${wpac_timeout} -ge 40 ]; then
+        # If wpa_supplicant hasn't connected within 15 seconds, assume it never will, and tear down Wi-Fi
+        if [ ${wpac_timeout} -ge 60 ]; then
             echo "[$(date)] restore-wifi-async.sh: Failed to connect to preferred AP!"
             ./disable-wifi.sh
             return 1
@@ -21,7 +21,7 @@ RestoreWifi() {
 
     ./obtain-ip.sh
 
-    echo "[$(date)] restore-wifi-async.sh: Restarted WiFi"
+    echo "[$(date)] restore-wifi-async.sh: Restarted Wi-Fi"
 }
 
 RestoreWifi &

--- a/platform/remarkable/README_remarkable.txt
+++ b/platform/remarkable/README_remarkable.txt
@@ -1,6 +1,6 @@
 # General
 
-When connected to WiFi you can find the IP address and root password for your
+When connected to Wi-Fi you can find the IP address and root password for your
 reMarkable in Settings -> About, then scroll down the GPLv3 compliance on the
 right (finger drag scroll, not the page forward/back buttons). This should also
 work for the USB network you get if you connect the reMarkable to your computer

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -178,11 +178,11 @@ while [ ${RETURN_VALUE} -ne 0 ]; do
         fi
         # U+1F4A3, the hard way, because we can't use \u or \U escape sequences...
         # shellcheck disable=SC2039
-        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} $'\xf0\x9f\x92\xa3'
+        ./fbink -q -b -O -m -t regular=./fonts/freefont/FreeSerif.ttf,px=${bombHeight},top=${bombMargin} -- $'\xf0\x9f\x92\xa3'
         # And then print the tail end of the log on the bottom of the screen...
         crashLog="$(tail -n 25 crash.log | sed -e 's/\t/    /g')"
         # The idea for the margins being to leave enough room for an fbink -Z bar, small horizontal margins, and a font size based on what 6pt looked like @ 265dpi
-        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) "${crashLog}"
+        ./fbink -q -b -O -t regular=./fonts/droid/DroidSansMono.ttf,top=$((viewHeight / 2 + FONTH * 2 + FONTH / 2)),left=$((viewWidth / 60)),right=$((viewWidth / 60)),px=$((viewHeight / 64)) -- "${crashLog}"
         # So far, we hadn't triggered an actual screen refresh, do that now, to make sure everything is bundled in a single flashing refresh.
         ./fbink -q -f -s
         # Cue a lemming's faceplant sound effect!

--- a/platform/sony-prstux/set-wifi.sh
+++ b/platform/sony-prstux/set-wifi.sh
@@ -5,9 +5,9 @@ if [ "$1" = "on" ]; then
     wmiconfig -i wlan0 --wlan enable
     wmiconfig -i wlan0 --setreassocmode 0
     wmiconfig -i wlan0 --power maxperf
-    echo "WiFi Enabled"
+    echo "Wi-Fi Enabled"
 else
     wmiconfig -i wlan0 --abortscan
     wmiconfig -i wlan0 --wlan disable
-    echo "Wifi Disabled"
+    echo "Wi-Fi Disabled"
 fi

--- a/platform/sony-prstux/suspend.sh
+++ b/platform/sony-prstux/suspend.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-# disable WiFi
+# disable Wi-Fi
 ./set-wifi.sh off
 
 # enter sleep, disabling all devices except CPU

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -203,6 +203,10 @@ Do you want to continue? ]]), driver),
 end
 
 function CalibreWireless:connect()
+    if NetworkMgr:willRerunWhenConnected(function() self:connect() end) then
+        return
+    end
+
     self.connect_message = false
     local host, port
     if G_reader_settings:hasNot("calibre_wireless_url") then
@@ -231,8 +235,6 @@ function CalibreWireless:connect()
         else
             self:setInboxDir(host, port)
         end
-    elseif not NetworkMgr:isConnected() then
-        NetworkMgr:promptWifiOn()
     else
         logger.info("cannot connect to calibre server")
         UIManager:show(InfoMessage:new{

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -11,6 +11,7 @@ local logger = require("logger")
 local util = require("ffi/util")
 local splitFilePathName = require("util").splitFilePathName
 local _ = require("gettext")
+local N_ = _.ngettext
 local T = require("ffi/util").template
 
 -- Util functions needed by this plugin, but that may be added to existing base/ffi/ files
@@ -776,7 +777,7 @@ Do you want to prune the cache of removed books?]]
     UIManager:close(info)
 
     if refresh_existing then
-        info = InfoMessage:new{text = T(_("Found %1 books to index."), #files)}
+        info = InfoMessage:new{text = T(N_("Found 1 book to index.", "Found %1 books to index."), #files)}
         UIManager:show(info)
         UIManager:forceRePaint()
         util.sleep(2) -- Let the user see that
@@ -823,7 +824,7 @@ Do you want to prune the cache of removed books?]]
             end
         end
         UIManager:close(info)
-        info = InfoMessage:new{text = T(_("Found %1 books to index."), #files)}
+        info = InfoMessage:new{text = T(N_("Found 1 book to index.", "Found %1 books to index."), #files)}
         UIManager:show(info)
         UIManager:forceRePaint()
         util.sleep(2) -- Let the user see that

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -34,6 +34,10 @@ local BookInfoManager = require("bookinfomanager")
 local current_path = nil
 local current_cover_specs = false
 
+-- Do some collectgarbage() every few drawings
+local NB_DRAWINGS_BETWEEN_COLLECTGARBAGE = 5
+local nb_drawings_since_last_collectgarbage = 0
+
 -- Simple holder of methods that will replace those
 -- in the real Menu class or instance
 local CoverMenu = {}
@@ -78,8 +82,17 @@ function CoverMenu:updateItems(select_number)
     -- and getting stuck...
     -- With this, garbage collecting may be more deterministic, and it has
     -- no negative impact on user experience.
-    collectgarbage()
-    collectgarbage()
+    -- But don't do it on every drawing, to not have all of them slow
+    -- when memory usage is already high
+    nb_drawings_since_last_collectgarbage = nb_drawings_since_last_collectgarbage + 1
+    if nb_drawings_since_last_collectgarbage >= NB_DRAWINGS_BETWEEN_COLLECTGARBAGE then
+        -- (delay it a bit so this pause is less noticable)
+        UIManager:scheduleIn(0.2, function()
+            collectgarbage()
+            collectgarbage()
+        end)
+        nb_drawings_since_last_collectgarbage = 0
+    end
 
     -- Specific UI building implementation (defined in some other module)
     self._has_cover_images = false
@@ -642,6 +655,11 @@ end
 function CoverMenu:onCloseWidget()
     -- Due to close callback in FileManagerHistory:onShowHist, we may be called
     -- multiple times (witnessed that with print(debug.traceback())
+    -- So, avoid doing what follows twice
+    if self._covermenu_onclose_done then
+        return
+    end
+    self._covermenu_onclose_done = true
 
     -- Stop background job if any (so that full cpu is available to reader)
     logger.dbg("CoverMenu:onCloseWidget: terminating jobs if needed")
@@ -663,8 +681,12 @@ function CoverMenu:onCloseWidget()
     self.cover_info_cache = nil
 
     -- Force garbage collecting when leaving too
-    collectgarbage()
-    collectgarbage()
+    -- (delay it a bit so this pause is less noticable)
+    UIManager:scheduleIn(0.2, function()
+        collectgarbage()
+        collectgarbage()
+    end)
+    nb_drawings_since_last_collectgarbage = 0
 
     -- Call original Menu:onCloseWidget (no subclass seems to override it)
     Menu.onCloseWidget(self)

--- a/plugins/goodreads.koplugin/main.lua
+++ b/plugins/goodreads.koplugin/main.lua
@@ -170,16 +170,16 @@ end
 -- search_type = author - serch book by author
 -- search_type = title - search book by title
 function Goodreads:search(search_type)
+    if NetworkMgr:willRerunWhenOnline(function() self:search(search_type) end) then
+       return
+    end
+
     local title_header
     local hint
     local search_input
     local text_input
     local info
     local result
-    if not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
-        return
-    end
     if search_type == "all" then
         title_header = _("Search all books in Goodreads")
         hint = _("Title, author or ISBN")

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -295,10 +295,10 @@ function KOSync:setWhisperBackward(strategy)
 end
 
 function KOSync:login()
-    if not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
+    if NetworkMgr:willRerunWhenOnline(function() self:login() end) then
         return
     end
+
     self.login_dialog = LoginDialog:new{
         title = self.title,
         username = self.kosync_username or "",

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -22,7 +22,6 @@ local NewsDownloader = WidgetContainer:new{
 }
 
 local initialized = false
-local wifi_enabled_before_action = true
 local feed_config_file_name = "feed_config.lua"
 local news_downloader_config_file = "news_downloader_settings.lua"
 local news_downloader_settings
@@ -59,13 +58,6 @@ local function getFeedLink(possible_link)
     end
 end
 
---- @todo Implement as NetworkMgr:afterWifiAction with configuration options.
-function NewsDownloader:afterWifiAction()
-    if not wifi_enabled_before_action then
-        NetworkMgr:promptWifiOff()
-    end
-end
-
 function NewsDownloader:init()
     self.ui.menu:registerToMainMenu(self)
 end
@@ -79,12 +71,7 @@ function NewsDownloader:addToMainMenu(menu_items)
                 text = _("Download news"),
                 keep_menu_open = true,
                 callback = function()
-                    if not NetworkMgr:isOnline() then
-                        wifi_enabled_before_action = false
-                        NetworkMgr:beforeWifiAction(self.loadConfigAndProcessFeedsWithUI)
-                    else
-                        self:loadConfigAndProcessFeedsWithUI()
-                    end
+                    NetworkMgr:runWhenOnline(function() self:loadConfigAndProcessFeedsWithUI() end)
                 end,
             },
             {
@@ -222,7 +209,7 @@ function NewsDownloader:loadConfigAndProcessFeeds()
         end
         UI:info(T(_("Downloading news finished. Could not process some feeds. Unsupported format in: %1"), unsupported_urls))
     end
-    NewsDownloader:afterWifiAction()
+    NetworkMgr:afterWifiAction()
 end
 
 function NewsDownloader:loadConfigAndProcessFeedsWithUI()

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -104,13 +104,13 @@ function Profiles:getSubMenuItems()
                 end,
             }
         }
-        Dispatcher.addSubMenu(self, sub_items, "data", k)
+        Dispatcher:addSubMenu(sub_items, self.data, k)
         table.insert(sub_item_table, {
             text = k,
             hold_keep_menu_open = false,
             sub_item_table = sub_items,
             hold_callback = function()
-                Dispatcher.execute(self, self.data[k])
+                Dispatcher:execute(self.ui, self.data[k])
             end,
         })
     end

--- a/plugins/send2ebook.koplugin/main.lua
+++ b/plugins/send2ebook.koplugin/main.lua
@@ -21,7 +21,6 @@ local Send2Ebook = WidgetContainer:new{
 }
 
 local initialized = false
-local wifi_enabled_before_action = true
 local send2ebook_config_file = "send2ebook_settings.lua"
 local config_key_custom_dl_dir = "custom_dl_dir";
 local default_download_dir_name = "send2ebook"
@@ -45,13 +44,6 @@ function Send2Ebook:downloadFileAndRemove(connection_url, remote_path, local_dow
     end
 end
 
---- @todo Implement as NetworkMgr:afterWifiAction with configuration options.
-function Send2Ebook:afterWifiAction()
-    if not wifi_enabled_before_action then
-        NetworkMgr:promptWifiOff()
-    end
-end
-
 function Send2Ebook:init()
     self.ui.menu:registerToMainMenu(self)
 end
@@ -65,12 +57,10 @@ function Send2Ebook:addToMainMenu(menu_items)
                 text = _("Download and remove from server"),
                 keep_menu_open = true,
                 callback = function()
-                  if not NetworkMgr:isOnline() then
-                      wifi_enabled_before_action = false
-                      NetworkMgr:beforeWifiAction(self.process)
-                  else
-                      self:process()
-                  end
+                    local connect_callback = function()
+                        self:process()
+                    end
+                    NetworkMgr:runWhenOnline(connect_callback)
                 end,
             },
             {
@@ -171,7 +161,7 @@ function Send2Ebook:process()
           end
     end
     UIManager:show(info)
-    Send2Ebook:afterWifiAction()
+    NetworkMgr:afterWifiAction()
 end
 
 function Send2Ebook:removeReadActicles()

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -273,7 +273,7 @@ Please wait…
                 UIManager:close(info)
                 UIManager:forceRePaint()
                 UIManager:show(InfoMessage:new{
-                    text =T(_("Conversion completed.\nImported %1 books to database.\nTap to continue."),nr_book) })
+                    text = T(N_("Conversion complete.\nImported one book to the database.\nTap to continue.", "Conversion complete.\nImported %1 books to the database.\nTap to continue."), nr_book) })
             else
                 self:createDB(conn)
             end

--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -34,7 +34,7 @@ local function currentTime()
     return _("Time synchronized.")
 end
 
-local function execute()
+local function syncNTP()
     local info = InfoMessage:new{
         text = _("Synchronizing time. This may take several seconds.")
     }
@@ -58,11 +58,7 @@ local menuItem = {
     text = _("Synchronize time"),
     keep_menu_open = true,
     callback = function()
-        if NetworkMgr:isOnline() then
-            execute()
-        else
-            NetworkMgr:promptWifiOn()
-        end
+        NetworkMgr:runWhenOnline(function() syncNTP() end)
     end
 }
 

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -112,15 +112,14 @@ function Wallabag:addToMainMenu(menu_items)
             {
                 text = _("Delete finished articles remotely"),
                 callback = function()
-                    if not NetworkMgr:isOnline() then
-                        NetworkMgr:promptWifiOn()
-                        return
+                    local connect_callback = function()
+                        local num_deleted = self:processLocalFiles("manual")
+                        UIManager:show(InfoMessage:new{
+                            text = T(_("Articles processed.\nDeleted: %1"), num_deleted)
+                        })
+                        self:refreshCurrentDirIfNeeded()
                     end
-                    local num_deleted = self:processLocalFiles("manual")
-                    UIManager:show(InfoMessage:new{
-                        text = T(_("Articles processed.\nDeleted: %1"), num_deleted)
-                    })
-                    self:refreshCurrentDirIfNeeded()
+                    NetworkMgr:runWhenOnline(connect_callback)
                 end,
                 enabled_func = function()
                     return self.is_delete_finished or self.is_delete_read
@@ -1078,12 +1077,11 @@ function Wallabag:onAddWallabagArticle(article_url)
 end
 
 function Wallabag:onSynchronizeWallabag()
-    if not NetworkMgr:isOnline() then
-        NetworkMgr:promptWifiOn()
-        return
+    local connect_callback = function()
+        self:synchronize()
+        self:refreshCurrentDirIfNeeded()
     end
-    self:synchronize()
-    self:refreshCurrentDirIfNeeded()
+    NetworkMgr:runWhenOnline(connect_callback)
 
     -- stop propagation
     return true

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -674,7 +674,7 @@ function Wallabag:processRemoteDeletes(remote_article_ids)
     end
     logger.dbg("Wallabag: articles IDs from server: ", remote_article_ids)
 
-    local info = InfoMessage:new{ text = _("Synchonising remote deletions…") }
+    local info = InfoMessage:new{ text = _("Synchronizing remote deletions…") }
     UIManager:show(info)
     UIManager:forceRePaint()
     UIManager:close(info)

--- a/plugins/zsync.koplugin/main.lua
+++ b/plugins/zsync.koplugin/main.lua
@@ -41,15 +41,14 @@ function ZSync:addToMainMenu(menu_items)
                 end,
                 callback = function()
                     local NetworkMgr = require("ui/network/manager")
-                    if not NetworkMgr:isOnline() then
-                        NetworkMgr:promptWifiOn()
-                        return
+                    local connect_callback = function()
+                        if not self.filemq_server then
+                            self:publish()
+                        else
+                            self:unpublish()
+                        end
                     end
-                    if not self.filemq_server then
-                        self:publish()
-                    else
-                        self:unpublish()
-                    end
+                    NetworkMgr:runWhenOnline(connect_callback)
                 end
             },
             {
@@ -63,15 +62,14 @@ function ZSync:addToMainMenu(menu_items)
                 end,
                 callback = function()
                     local NetworkMgr = require("ui/network/manager")
-                    if not NetworkMgr:isOnline() then
-                        NetworkMgr:promptWifiOn()
-                        return
+                    local connect_callback = function()
+                        if not self.filemq_client then
+                            self:subscribe()
+                        else
+                            self:unsubscribe()
+                        end
                     end
-                    if not self.filemq_client then
-                        self:subscribe()
-                    else
-                        self:unsubscribe()
-                    end
+                    NetworkMgr:runWhenOnline(connect_callback)
                 end
             }
         }

--- a/spec/unit/networksetting_spec.lua
+++ b/spec/unit/networksetting_spec.lua
@@ -12,7 +12,7 @@ describe("NetworkSetting module", function()
         assert.is.falsy(ns.connected_item)
     end)
 
-    it("should call connect_callback after disconnect", function()
+    it("should NOT call connect_callback after disconnect", function()
         stub(NetworkMgr, "disconnectNetwork")
         stub(NetworkMgr, "releaseIP")
 
@@ -31,6 +31,33 @@ describe("NetworkSetting module", function()
         local ns = NetworkSetting:new{
             network_list = network_list,
             connect_callback = function() called = true end
+        }
+        ns.connected_item:disconnect()
+        assert.falsy(called)
+
+        NetworkMgr.disconnectNetwork:revert()
+        NetworkMgr.releaseIP:revert()
+    end)
+
+    it("should call disconnect_callback after disconnect", function()
+        stub(NetworkMgr, "disconnectNetwork")
+        stub(NetworkMgr, "releaseIP")
+
+        UIManager:quit()
+        local called = false
+        local network_list = {
+            {
+                ssid = "foo",
+                signal_level = -58,
+                flags = "[WPA2-PSK-CCMP][ESS]",
+                signal_quality = 84,
+                password = "123abc",
+                connected = true,
+            },
+        }
+        local ns = NetworkSetting:new{
+            network_list = network_list,
+            disconnect_callback = function() called = true end
         }
         ns.connected_item:disconnect()
         assert.truthy(called)

--- a/spec/unit/readerfooter_spec.lua
+++ b/spec/unit/readerfooter_spec.lua
@@ -6,7 +6,11 @@ describe("Readerfooter module", function()
     setup(function()
         require("commonrequire")
         package.unloadAll()
-        require("document/canvascontext"):init(require("device"))
+        local Device = require("device")
+        -- Override powerd for running tests on devices with batteries.
+        Device.powerd.isChargingHW = function() return false end
+        Device.powerd.getCapacityHW = function() return 0 end
+        require("document/canvascontext"):init(Device)
         DocumentRegistry = require("document/documentregistry")
         DocSettings = require("docsettings")
         ReaderUI = require("apps/reader/readerui")


### PR DESCRIPTION
Hi @zwim. Unfortunately both the android-luajit-launcher and the koreader branches diverged a bit, so I'm not able to propose a clean PR on your NativeLights branch and I need to cherry-pick the bits you changed in android-luajit-launcher.

Since I would like your ok before pushing to your branch I submit the PR here. Please do review just the last commit. The rest are just unrelated (the result of `git rebase master`)

I moved the frontlight wrapper to frontend/device/android/device, since it makes a bit more sense there and removes a few imports.  This way the code in frontend/ui/elements just overrides the frontlight on android while the implementation is in Device:lightDialog.

Please keep me updated!